### PR TITLE
add options.imageCrossOrigin

### DIFF
--- a/src/api/preCache.js
+++ b/src/api/preCache.js
@@ -18,11 +18,12 @@ import { imageCache, bgCache, resourceCache, baseCSSCache, computedStyleCache } 
  * @param {boolean} [options.embedFonts=true] - Whether to embed custom fonts
  * @param {boolean} [options.reset=false] - Whether to clear all caches before pre-caching
  * @param {boolean} [options.preWarm=true] - Whether to pre-cache common tag styles
+ * @param {Function} [options.imageCrossOrigin] - Function that returns CORS mode for each image URL
  * @returns {Promise<void>} Resolves when all resources are pre-cached
  */
 
 export async function preCache(root = document, options = {}) {
-  const { embedFonts = true, reset = false, preWarm = true } = options;
+  const { embedFonts = true, reset = false, imageCrossOrigin } = options;
   if (reset) {
     imageCache.clear();
     bgCache.clear();
@@ -45,8 +46,9 @@ export async function preCache(root = document, options = {}) {
   for (const img of imgEls) {
     const src = img.src;
     if (!imageCache.has(src)) {
+      const crossOrigin = imageCrossOrigin ? imageCrossOrigin(src) : "anonymous";
       promises.push(
-        fetchImage(src)
+        fetchImage(src, 3000, crossOrigin)
           .then(dataURL => imageCache.set(src, dataURL))
           .catch(() => {})
       );
@@ -56,8 +58,9 @@ export async function preCache(root = document, options = {}) {
     const bg = getComputedStyle(el).backgroundImage;
     const url = extractURL(bg);
     if (url && !bgCache.has(url)) {
+      const crossOrigin = imageCrossOrigin ? imageCrossOrigin(url) : "anonymous";
       promises.push(
-        fetchImage(url)
+        fetchImage(url, 3000, crossOrigin)
           .then(dataURL => bgCache.set(url, dataURL))
           .catch(() => {})
       );

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -34,13 +34,13 @@ export async function captureDOM(element, options = {}) {
   ({ clone, classCSS, styleCache } = await prepareClone(element, compress, embedFonts));
   await new Promise((resolve) => {
     idle(async () => {
-      await inlineImages(clone);
+      await inlineImages(clone, options);
       resolve();
     }, { fast });
   });
   await new Promise((resolve) => {
     idle(async () => {
-      await inlineBackgroundImages(element, clone, styleCache);
+      await inlineBackgroundImages(element, clone, styleCache, options);
       resolve();
     }, { fast });
   });

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -12,9 +12,10 @@ import { bgCache } from '../core/cache.js'
  * @param {Element} source - Original element
  * @param {Element} clone - Cloned element
  * @param {WeakMap} styleCache - Cache of computed styles
+ * @param {Object} [options={}] - Options for image processing
  * @returns {Promise<void>} Promise that resolves when all background images are processed
  */
-export async function inlineBackgroundImages(source, clone, styleCache) {
+export async function inlineBackgroundImages(source, clone, styleCache, options = {}) {
   const queue = [[source, clone]];
   while (queue.length) {
     const [srcNode, cloneNode] = queue.shift();
@@ -29,7 +30,8 @@ export async function inlineBackgroundImages(source, clone, styleCache) {
         if (bgCache.has(bgUrl)) {
           dataUrl = bgCache.get(bgUrl);
         } else {
-          dataUrl = await fetchImage(bgUrl);
+          const crossOrigin = options.imageCrossOrigin ? options.imageCrossOrigin(bgUrl) : "anonymous";
+          dataUrl = await fetchImage(bgUrl, 3000, crossOrigin);
           bgCache.set(bgUrl, dataUrl);
         }
         cloneNode.style.backgroundImage = `url(${dataUrl})`;

--- a/src/modules/images.js
+++ b/src/modules/images.js
@@ -9,14 +9,16 @@ import { fetchImage } from '../utils/helpers.js';
  * Converts all <img> elements in the clone to data URLs or replaces them with placeholders if loading fails.
  *
  * @param {Element} clone - Clone of the original element
+ * @param {Object} [options={}] - Options for image processing
  * @returns {Promise<void>} Promise that resolves when all images are processed
  */
-export async function inlineImages(clone) {
+export async function inlineImages(clone, options = {}) {
   const imgs = Array.from(clone.querySelectorAll("img"));
   const processImg = async (img) => {
     const src = img.src;
     try {
-      const dataUrl = await fetchImage(src);
+      const crossOrigin = options.imageCrossOrigin ? options.imageCrossOrigin(src) : "anonymous";
+      const dataUrl = await fetchImage(src, 3000, crossOrigin);
       img.src = dataUrl;
       if (!img.width) img.width = img.naturalWidth || 100;
       if (!img.height) img.height = img.naturalHeight || 100;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -106,7 +106,7 @@ export function isIconFont(familyOrUrl) {
  * @param {number} [timeout=3000]
  * @return {*} 
  */
-export function fetchImage(src, timeout = 3000) {
+export function fetchImage(src, timeout = 3000, crossOrigin = "anonymous") {
 
   if (imageCache.has(src)) {
     return Promise.resolve(imageCache.get(src));
@@ -118,7 +118,7 @@ export function fetchImage(src, timeout = 3000) {
     }, timeout);
 
     const image = new Image();
-    image.crossOrigin = "anonymous";
+    image.crossOrigin = crossOrigin;
 
     image.onload = async () => {
       clearTimeout(timeoutId);

--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -9,6 +9,7 @@ declare module "@zumer/snapdom" {
     filename?: string;
     dpr?: number;
     quality?: number;
+    imageCrossOrigin?: (url: string) => "anonymous" | "use-credentials";
   }
 
   export interface SnapResult {
@@ -51,6 +52,7 @@ declare module "@zumer/snapdom" {
     root?: Document | HTMLElement,
     options?: {
       embedFonts?: boolean;
+      imageCrossOrigin?: (url: string) => "anonymous" | "use-credentials";
     }
   ): Promise<void>;
 }


### PR DESCRIPTION
Allows the image crossOrigin to be set per image. 

e.g.

```typescript
  await snapdom(element, {
    imageCrossOrigin: (url: string) => {
      // Use credentials for same-origin images
      if (url.startsWith(window.location.origin)) {
        return "use-credentials";
      }
      // Use anonymous for cross-origin images
      return "anonymous";
    }
  });
```