### PR TITLE
Add Lucide to icon font detection

### DIFF
--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -42,7 +42,7 @@ export async function inlinePseudoElements(source, clone, styleMap, styleCache, 
         const key = getStyleKey(snapshot, "span", compress);
         styleMap.set(pseudoEl, key);
 
-        const isIconFont2 = fontFamily && /font.*awesome|material|bootstrap|glyphicons|ionicons|remixicon|simple-line-icons|octicons|feather|typicons|weathericons/i.test(
+        const isIconFont2 = fontFamily && /font.*awesome|material|bootstrap|glyphicons|ionicons|remixicon|simple-line-icons|octicons|feather|typicons|weathericons|lucide/i.test(
           fontFamily
         );
         let cleanContent = parseContent(content);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -95,6 +95,7 @@ export function isIconFont(familyOrUrl) {
     /bootstrap\s*icons/i,
     /remix\s*icons/i,
     /heroicons/i,
+    /lucide/i
   ];
   return iconFontPatterns.some(rx => rx.test(familyOrUrl));
 }


### PR DESCRIPTION
Updated regex patterns in `pseudo.js` and `helpers.js` to include `lucide` as a recognized icon font.

I'm not sure about the usage of `isIconFont`, but I added the font there also.

I created another issue to improve the logic.

Fixes #30 