### PR TITLE
fix: encode same uri multiple times

### DIFF
--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -3,7 +3,7 @@
  * @module background
  */
 
-import { fetchImage, getStyle, extractURL } from '../utils/helpers.js';
+import { fetchImage, getStyle, extractURL, safeEncodeURI } from '../utils/helpers.js';
 import { bgCache } from '../core/cache.js'
 
 /**
@@ -52,7 +52,7 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
           if (!rawUrl) return entry;
 
           try {
-            const encodedUrl = encodeURI(rawUrl);
+            const encodedUrl = safeEncodeURI(rawUrl);
             if (bgCache.has(encodedUrl)) {
               return `url(${bgCache.get(encodedUrl)})`;
             } else {

--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -3,7 +3,7 @@
  * @module pseudo
  */
 
-import { fetchImage, getStyle, extractURL } from '../utils/helpers.js'
+import { fetchImage, getStyle, extractURL, safeEncodeURI } from '../utils/helpers.js'
 import { snapshotComputedStyle } from '../utils/helpers.js'
 import { parseContent } from '../utils/helpers.js'
 import { getStyleKey } from '../utils/cssTools.js'
@@ -104,7 +104,7 @@ export async function inlinePseudoElements(source, clone, styleMap, styleCache, 
           if (rawUrl && rawUrl.trim() !== "") {
             try {
               const imgEl = document.createElement("img");
-              const dataUrl = await fetchImage(encodeURI(rawUrl));
+              const dataUrl = await fetchImage(safeEncodeURI(rawUrl));
               imgEl.src = dataUrl;
               imgEl.style = "display:block;width:100%;height:100%;object-fit:contain;";
               pseudoEl.appendChild(imgEl);
@@ -125,7 +125,7 @@ export async function inlinePseudoElements(source, clone, styleMap, styleCache, 
               if (rawUrl.startsWith("data:")) {
                 dataUrl = rawUrl; // no fetch necesario
               } else {
-                dataUrl = await fetchImage(encodeURI(rawUrl));
+                dataUrl = await fetchImage(safeEncodeURI(rawUrl));
               }
               pseudoEl.style.backgroundImage = `url(${dataUrl})`;
             } catch (e) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -193,3 +193,12 @@ export function stripTranslate(transform) {
 
   return cleaned.trim().replace(/\s{2,}/g, ' ');
 }
+
+export function safeEncodeURI(uri) {
+  try {
+    const newURI = decodeURI(uri);
+    return encodeURI(newURI);
+  } catch {
+    return uri;
+  }
+}


### PR DESCRIPTION
Issue: #64 

When a URI is already encoded, you should avoid applying encodeURI again to prevent incorrect double encoding when there are spaces in the uri.

uri: https://www.images.es/image%20with%20spaces.jpg

Problem:
`encodeURI(uri); // https://www.images.es/image%2520with%2520spaces.jpg BAD`

Expected:
`safeEncodeURI(uri); // https://www.images.es/image%20with%20spaces.jpg GOOD`