### PR TITLE
Missing `width` and `height` in types

### DIFF
--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -4,6 +4,8 @@ declare module "@zumer/snapdom" {
     embedFonts?: boolean;
     fast?: boolean;
     scale?: number;
+    width?: number;
+    height?: number;
     backgroundColor?: string;
     format?: "png" | "jpeg" | "jpg" | "webp" | "svg";
     filename?: string;


### PR DESCRIPTION
see https://github.com/zumerlab/snapdom/issues/93