### PR TITLE
copy `checkbox.indeterminate`

### DIFF
--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -108,6 +108,9 @@ export function deepClone(node, styleMap, styleCache, nodeMap, compress, options
       clone.checked = node.checked;
       if (node.checked) clone.setAttribute("checked", "");
     }
+    if(node.indeterminate) {
+      clone.indeterminate = node.indeterminate;
+    }
   }
   else if (node instanceof HTMLTextAreaElement) {
     clone.value = node.value;


### PR DESCRIPTION
`checkbox.indeterminate` is a property, so is not copied when copying attributes.

I haven't tested this, but I'm fairly confident that it works