### PR TITLE
fix: invalid border-width check

### DIFF
--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -3,11 +3,20 @@
  * @module pseudo
  */
 
-import { getStyle, snapshotComputedStyle, parseContent, extractURL, safeEncodeURI, fetchImage, inlineSingleBackgroundEntry, splitBackgroundImage } from '../utils/helpers.js';
+import {
+  getStyle,
+  snapshotComputedStyle,
+  parseContent,
+  extractURL,
+  safeEncodeURI,
+  fetchImage,
+  inlineSingleBackgroundEntry,
+  splitBackgroundImage,
+} from '../utils/helpers.js';
 import { getStyleKey } from '../utils/cssTools.js';
 import { iconToImage } from '../modules/fonts.js';
 import { isIconFont } from '../modules/iconFonts.js';
-import { cache } from '../core/cache.js'
+import { cache } from '../core/cache.js';
 
 /**
  * Creates elements to represent ::before, ::after, and ::first-letter pseudo-elements, inlining their styles and content.
@@ -21,13 +30,14 @@ import { cache } from '../core/cache.js'
 
 export async function inlinePseudoElements(source, clone, compress, embedFonts = false, useProxy) {
   if (!(source instanceof Element) || !(clone instanceof Element)) return;
-  for (const pseudo of ["::before", "::after", "::first-letter"]) {
+  for (const pseudo of ['::before', '::after', '::first-letter']) {
     try {
       const style = getStyle(source, pseudo);
-      if (!style || typeof style[Symbol.iterator] !== "function") continue;
-      if (pseudo === "::first-letter") {
+      if (!style || typeof style[Symbol.iterator] !== 'function') continue;
+      if (pseudo === '::first-letter') {
         const normal = getComputedStyle(source);
-        const isMeaningful = style.color !== normal.color || style.fontSize !== normal.fontSize || style.fontWeight !== normal.fontWeight;
+        const isMeaningful =
+          style.color !== normal.color || style.fontSize !== normal.fontSize || style.fontWeight !== normal.fontWeight;
         if (!isMeaningful) continue;
         const textNode = Array.from(clone.childNodes).find(
           (n) => n.nodeType === Node.TEXT_NODE && n.textContent && n.textContent.trim().length > 0
@@ -38,107 +48,102 @@ export async function inlinePseudoElements(source, clone, compress, embedFonts =
         const first = match?.[0];
         const rest = text.slice(first?.length || 0);
         if (!first || /[\uD800-\uDFFF]/.test(first)) continue;
-        const span = document.createElement("span");
+        const span = document.createElement('span');
         span.textContent = first;
-        span.dataset.snapdomPseudo = "::first-letter";
+        span.dataset.snapdomPseudo = '::first-letter';
         const snapshot = snapshotComputedStyle(style);
-        const key = getStyleKey(snapshot, "span", compress);
+        const key = getStyleKey(snapshot, 'span', compress);
         cache.preStyleMap.set(span, key);
         const restNode = document.createTextNode(rest);
         clone.replaceChild(restNode, textNode);
         clone.insertBefore(span, restNode);
         continue;
       }
-const content = style.getPropertyValue("content");
-const bg = style.getPropertyValue("background-image");
-const bgColor = style.getPropertyValue("background-color");
+      const content = style.content;
+      const bg = style.backgroundImage;
+      const bgColor = style.backgroundColor;
 
-const fontFamily = style.getPropertyValue("font-family");
-const fontSize = parseInt(style.getPropertyValue("font-size")) || 32;
-const fontWeight = parseInt(style.getPropertyValue("font-weight")) || false;
-const color = style.getPropertyValue("color") || "#000";
-const display = style.getPropertyValue("display");
-const width = parseFloat(style.getPropertyValue("width"));
-const height = parseFloat(style.getPropertyValue("height"));
-const borderStyle = style.getPropertyValue("border-style");
-const transform = style.getPropertyValue("transform");
+      const fontFamily = style.fontFamily;
+      const fontSize = parseInt(style.fontSize) || 32;
+      const fontWeight = parseInt(style.fontWeight) || false;
+      const color = style.color || '#000';
+      const display = style.display;
+      const width = parseFloat(style.width);
+      const height = parseFloat(style.height);
+      const borderStyle = style.borderStyle;
+      const transform = style.transform;
+      const borderWidth = parseFloat(style.borderWidth);
 
-const isIconFont2 = isIconFont(fontFamily);
+      const isIconFont2 = isIconFont(fontFamily);
 
-// Detect counter() || counters()
-let cleanContent;
-if (/counter\s*\(|counters\s*\(/.test(content)) {
-  cleanContent = "- ";
-} else {
-  cleanContent = parseContent(content);
-}
+      // Detect counter() || counters()
+      let cleanContent;
+      if (/counter\s*\(|counters\s*\(/.test(content)) {
+        cleanContent = '- ';
+      } else {
+        cleanContent = parseContent(content);
+      }
 
-const hasContent = content !== "none";
-const hasExplicitContent = hasContent && cleanContent !== "";
-const hasBg = bg && bg !== "none";
-const hasBgColor = bgColor && bgColor !== "transparent" && bgColor !== "rgba(0, 0, 0, 0)";
-const hasBox = display !== "inline" && (width > 0 || height > 0);
-const hasBorder = borderStyle && borderStyle !== "none";
-const hasTransform = transform && transform !== "none";
+      const hasContent = content !== 'none';
+      const hasExplicitContent = hasContent && cleanContent !== '';
+      const hasBg = bg && bg !== 'none';
+      const hasBgColor = bgColor && bgColor !== 'transparent' && bgColor !== 'rgba(0, 0, 0, 0)';
+      const hasBox = display !== 'inline' && (width > 0 || height > 0);
 
-const shouldRender =
-  hasExplicitContent || hasBg || hasBgColor || hasBox || hasBorder || hasTransform;
+      const hasBorder = borderStyle && borderStyle !== 'none' && borderWidth > 0;
+      const hasTransform = transform && transform !== 'none';
 
-if (!shouldRender) continue;
+      const shouldRender = hasExplicitContent || hasBg || hasBgColor || hasBox || hasBorder || hasTransform;
 
-const pseudoEl = document.createElement("span");
-pseudoEl.dataset.snapdomPseudo = pseudo;
-const snapshot = snapshotComputedStyle(style);
-const key = getStyleKey(snapshot, "span", compress);
-cache.preStyleMap.set(pseudoEl, key);
+      if (!shouldRender) continue;
 
-if (isIconFont2 && cleanContent.length === 1) {
-  const imgEl = document.createElement("img");
-  imgEl.src = await iconToImage(cleanContent, fontFamily, fontWeight, fontSize, color);
-  imgEl.style = `width:${fontSize}px;height:auto;object-fit:contain;`;
-  pseudoEl.appendChild(imgEl);
-} else if (cleanContent.startsWith("url(")) {
-  const rawUrl = extractURL(cleanContent);
-  if (rawUrl && rawUrl.trim() !== "") {
-    try {
-      const imgEl = document.createElement("img");
-      const dataUrl = await fetchImage(safeEncodeURI(rawUrl, { useProxy }));
-      imgEl.src = dataUrl;
-      imgEl.style = `width:${fontSize}px;height:auto;object-fit:contain;`;
-      pseudoEl.appendChild(imgEl);
-    } catch (e) {
-      console.error(`[snapdom] Error in pseudo ${pseudo} for`, source, e);
-    }
-  }
-} else if (!isIconFont2 && hasExplicitContent) {
-  pseudoEl.textContent = cleanContent;
-}
+      const pseudoEl = document.createElement('span');
+      pseudoEl.dataset.snapdomPseudo = pseudo;
+      const snapshot = snapshotComputedStyle(style);
+      const key = getStyleKey(snapshot, 'span', compress);
+      cache.preStyleMap.set(pseudoEl, key);
 
-if (hasBg) {
-  try {
-    const bgSplits = splitBackgroundImage(bg);
-    const newBgParts = await Promise.all(
-      bgSplits.map((entry) => inlineSingleBackgroundEntry(entry))
-    );
-    pseudoEl.style.backgroundImage = newBgParts.join(", ");
-  } catch (e) {
-    console.warn(`[snapdom] Failed to inline background-image for ${pseudo}`, e);
-  }
-}
+      if (isIconFont2 && cleanContent.length === 1) {
+        const imgEl = document.createElement('img');
+        imgEl.src = await iconToImage(cleanContent, fontFamily, fontWeight, fontSize, color);
+        imgEl.style = `width:${fontSize}px;height:auto;object-fit:contain;`;
+        pseudoEl.appendChild(imgEl);
+      } else if (cleanContent.startsWith('url(')) {
+        const rawUrl = extractURL(cleanContent);
+        if (rawUrl && rawUrl.trim() !== '') {
+          try {
+            const imgEl = document.createElement('img');
+            const dataUrl = await fetchImage(safeEncodeURI(rawUrl, { useProxy }));
+            imgEl.src = dataUrl;
+            imgEl.style = `width:${fontSize}px;height:auto;object-fit:contain;`;
+            pseudoEl.appendChild(imgEl);
+          } catch (e) {
+            console.error(`[snapdom] Error in pseudo ${pseudo} for`, source, e);
+          }
+        }
+      } else if (!isIconFont2 && hasExplicitContent) {
+        pseudoEl.textContent = cleanContent;
+      }
 
-if (hasBgColor) pseudoEl.style.backgroundColor = bgColor;
+      if (hasBg) {
+        try {
+          const bgSplits = splitBackgroundImage(bg);
+          const newBgParts = await Promise.all(bgSplits.map((entry) => inlineSingleBackgroundEntry(entry)));
+          pseudoEl.style.backgroundImage = newBgParts.join(', ');
+        } catch (e) {
+          console.warn(`[snapdom] Failed to inline background-image for ${pseudo}`, e);
+        }
+      }
 
-const hasContent2 =
-  pseudoEl.childNodes.length > 0 ||
-  (pseudoEl.textContent && pseudoEl.textContent.trim() !== "");
-const hasVisibleBox = hasContent2 || hasBg || hasBgColor || hasBox || hasBorder || hasTransform;
+      if (hasBgColor) pseudoEl.style.backgroundColor = bgColor;
 
-if (!hasVisibleBox) continue;
+      const hasContent2 =
+        pseudoEl.childNodes.length > 0 || (pseudoEl.textContent && pseudoEl.textContent.trim() !== '');
+      const hasVisibleBox = hasContent2 || hasBg || hasBgColor || hasBox || hasBorder || hasTransform;
 
-pseudo === "::before"
-  ? clone.insertBefore(pseudoEl, clone.firstChild)
-  : clone.appendChild(pseudoEl);
+      if (!hasVisibleBox) continue;
 
+      pseudo === '::before' ? clone.insertBefore(pseudoEl, clone.firstChild) : clone.appendChild(pseudoEl);
     } catch (e) {
       console.warn(`[snapdom] Failed to capture ${pseudo} for`, source, e);
     }
@@ -146,12 +151,6 @@ pseudo === "::before"
   const sChildren = Array.from(source.children);
   const cChildren = Array.from(clone.children).filter((child) => !child.dataset.snapdomPseudo);
   for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
-    await inlinePseudoElements(
-      sChildren[i],
-      cChildren[i],
-      compress,
-      embedFonts,
-      useProxy
-    );
+    await inlinePseudoElements(sChildren[i], cChildren[i], compress, embedFonts, useProxy);
   }
 }


### PR DESCRIPTION
Previous: `const hasBorder = borderStyle && borderStyle !== 'none';`

Now: `const hasBorder = borderStyle && borderStyle !== 'none' && parseFloat(style.getPropertyValue('border-width')) > 0;`

In the current code, even if the border style is set to `hidden` or `transparent`, it will still be matched. I added the `border-width` check to solve this problem.
