### PR TITLE
feat: optimize canvas image render load

### DIFF
--- a/src/api/snapdom.js
+++ b/src/api/snapdom.js
@@ -62,7 +62,7 @@ async function toCanvas(url, { dpr = 1, scale = 1 } = {}) {
       if (img.complete) resolve(null);
       const onLoad = () => {
         img.removeEventListener('load', onLoad);
-        resolve(null);
+        requestAnimationFrame(requestAnimationFrame(() => resolve(null)));
       };
       const onError = () => {
         img.removeEventListener('error', onError);


### PR DESCRIPTION
1. `await new Promise(resolve => setTimeout(resolve, 100));` is confused, and this depend on networks so sometimes takes no effect. I replaced this logic with an `onLoad` event callback to handle this issue.
2. Only Safari should append images, so adding `append` variable is redundant.
