### PR TITLE
✨ feat:Page jam caused by long deepClone stacks

### DIFF
--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -39,7 +39,7 @@ export async function prepareClone(element, compress = false, embedFonts = false
 
 
   try {
-    clone = deepClone(element, styleMap, styleCache, nodeMap, compress, options, element);
+    clone = await deepClone(element, styleMap, styleCache, nodeMap, compress, options, element);
   } catch (e) {
     console.warn("deepClone failed:", e);
     throw e;

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -70,14 +70,18 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
       // Split multiple background images (e.g., comma-separated) for inlining each separately
       const splits = splitBackgroundImage(val);
 
-      // Inline each background image entry asynchronously (e.g., fetch and embed as data URI)
-      const inlined = await Promise.all(
-        splits.map(entry => inlineSingleBackgroundEntry(entry, options))
-      );
+      try {
 
-      // If any inlined entry is valid, set the joined inline style on the clone
-      if (inlined.some(p => p && p !== "none" && !/^url\(undefined/.test(p))) {
-        cloneNode.style.setProperty(prop, inlined.join(", "));
+        // Inline each background image entry asynchronously (e.g., fetch and embed as data URI)
+        const inlined = await Promise.all(
+          splits.map(entry => inlineSingleBackgroundEntry(entry, options))
+        );
+  
+        // If any inlined entry is valid, set the joined inline style on the clone
+        if (inlined.some(p => p && p !== "none" && !/^url\(undefined/.test(p))) {
+          cloneNode.style.setProperty(prop, inlined.join(", "));
+        }
+      } catch (e) {
       }
     }
 

--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -17,6 +17,7 @@ declare module "@zumer/snapdom" {
     useProxy?: string;
     exclude?: string[];
     filter?: (element: Element, originalElement: Element) => boolean;
+    performance?: boolean;
   }
 
   export interface SnapResult {


### PR DESCRIPTION
1.Dom clone through options.performance uses idle to minimize the consumption of page rendering frames for large time-consuming tasks 
2.background.js image resource 404 should not be a direct exception leading to execution failure

Before modification
<img width="1755" height="701" alt="54fa74d9fa0c4c088b56b9bf92681035" src="https://github.com/user-attachments/assets/c45c30e4-a3f5-4d0f-bfd3-c1600306f13b" />


After modification
<img width="1234" height="478" alt="0c0354c1e66c40b6805a6591ac02156a" src="https://github.com/user-attachments/assets/9b1b1b56-80c2-4177-8fc2-cd496a72cfa6" />

When the level is deeper, this stack will only take longer, and the page rendering will get stuck in frames, or even worse.

Browsers that don't support requestIdleCallback, such as Safari, don't take effect, and the change slows down completion. However, it may be useful in situations where the user's performance needs to be prioritized more highly



