### PR TITLE
Adding 'exclusionMode' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ All capture methods accept an `options` object:
 | `type`            | string   | `svg`    | Default Blob type (`svg`\|`png`\|`jpg`\|`webp`) |
 | `exclude`         | string[] | -        | CSS selectors to exclude                        |
 | `filter`          | function | -        | Custom predicate `(el) => boolean`              |
+| `exclusionMode`   | string   | 'visuallyHide' | Control how `exclude` and `filter` works with nodes |
 | `cache`           | string   | `"soft"` | Control internal caches: `disabled`, `soft`, `auto`, `full` |
 | `defaultImageUrl` | string \| function  | -                  | Fallback image when an `<img>` fails. If a function is provided, it receives `{ width?, height?, src?, element }` and must return a URL (string or Promise<string>). Useful for placeholder services (e.g. `https://placehold.co/{width}x{height}`) |
 
@@ -305,6 +306,7 @@ await snapdom.toPng(el, {
 
 * `exclude`: remove by **selector**.
 * `filter`: advanced predicate per element (return `false` to drop).
+* `exclusionMode`: `visuallyHide` applies `visibility:hidden` CSS rule on node and the layout remains as the original. `remove` do not clone the node at all.
 
 **Example: filter out elements with `display:none`:**
 ```js
@@ -345,7 +347,7 @@ await preCache({
 
 ### Cache control
 
-SnapDOM maintains internal caches for images, backgrounds, resources, styles, and fonts.  
+SnapDOM maintains internal caches for images, backgrounds, resources, styles, and fonts.
 You can control how they are cleared between captures using the `cache` option:
 
 | Mode        | Description                                                                 |

--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ All capture methods accept an `options` object:
 | `useProxy`        | string   | `''`     | Proxy base for CORS fallbacks                   |
 | `type`            | string   | `svg`    | Default Blob type (`svg`\|`png`\|`jpg`\|`webp`) |
 | `exclude`         | string[] | -        | CSS selectors to exclude                        |
+| `excludeMode`     | string   | 'visuallyHide' | Controls how `exclude` works with nodes    |
 | `filter`          | function | -        | Custom predicate `(el) => boolean`              |
-| `exclusionMode`   | string   | 'visuallyHide' | Control how `exclude` and `filter` works with nodes |
+| `filterMode`      | string   | 'visuallyHide' | Controls how `filter` works with nodes    |
 | `cache`           | string   | `"soft"` | Control internal caches: `disabled`, `soft`, `auto`, `full` |
 | `defaultImageUrl` | string \| function  | -                  | Fallback image when an `<img>` fails. If a function is provided, it receives `{ width?, height?, src?, element }` and must return a URL (string or Promise<string>). Useful for placeholder services (e.g. `https://placehold.co/{width}x{height}`) |
 
@@ -305,8 +306,9 @@ await snapdom.toPng(el, {
 ### Filtering nodes: `exclude` vs `filter`
 
 * `exclude`: remove by **selector**.
+* `excludeMode`: `visuallyHide` applies `visibility:hidden` CSS rule on excluded nodes and the layout remains as the original. `remove` do not clone excluded nodes at all.
 * `filter`: advanced predicate per element (return `false` to drop).
-* `exclusionMode`: `visuallyHide` applies `visibility:hidden` CSS rule on node and the layout remains as the original. `remove` do not clone the node at all.
+* `filterMode`: `visuallyHide` applies `visibility:hidden` CSS rule on filtered nodes and the layout remains as the original. `remove` do not clone filtered nodes at all.
 
 **Example: filter out elements with `display:none`:**
 ```js

--- a/__tests__/core.clone.more.test.js
+++ b/__tests__/core.clone.more.test.js
@@ -77,17 +77,17 @@ describe('deepClone – extra coverage', () => {
   warn.mockRestore()
 })
 
-it('exclude by selector with exclusionMode = "remove" skips element from clonning', async () => {
+it('exclude by selector with excludeMode = "remove" skips element from clonning', async () => {
   const el = document.createElement('div');
   el.classList.add('exclude-me');
-  const out = await deepClone(el, session, { exclude: ['.exclude-me'], exclusionMode: 'remove' })
+  const out = await deepClone(el, session, { exclude: ['.exclude-me'], excludeMode: 'remove' })
   expect(out).not.toBeInstanceOf(HTMLElement)
 });
 
   it('excludes by custom filter returning false; and handles filter error', async () => {
     // filter false -> spacer
     const a = document.createElement('p')
-    const out1 = await deepClone(a, session, { filter: () => false, exclusionMode: 'visuallyHide' })
+    const out1 = await deepClone(a, session, { filter: () => false, filterMode: 'visuallyHide' })
     expect(out1).toBeInstanceOf(HTMLElement)
     expect(out1.style.visibility).toBe('hidden')
 
@@ -100,10 +100,10 @@ it('exclude by selector with exclusionMode = "remove" skips element from clonnin
     warn.mockRestore()
   });
 
-  if ('custom filter with exclusionMode = "remove" skips element from clonning', async () => {
+  if ('custom filter with filterMode = "remove" skips element from clonning', async () => {
     // filter false -> null
     const a = document.createElement('p')
-    const out1 = await deepClone(a, session, { filter: () => false, exclusionMode: 'remove' })
+    const out1 = await deepClone(a, session, { filter: () => false, filterMode: 'remove' })
     expect(out1).not.toBeInstanceOf(HTMLElement)
   });
 
@@ -200,10 +200,10 @@ it('exclude by selector with exclusionMode = "remove" skips element from clonnin
     expect(txt.nodeValue).toBe('slotted!')
   })
 
-  it('deepClone handles data-capture="exclude" with exclusionMode = "remove"', async () => {
+  it('deepClone handles data-capture="exclude" with excludeMode = "remove"', async () => {
     const el = document.createElement('div');
     el.setAttribute('data-capture', 'exclude');
-    const out1 = await deepClone(el, session, { exclusionMode: 'remove' })
+    const out1 = await deepClone(el, session, { excludeMode: 'remove' })
     expect(out1).not.toBeInstanceOf(HTMLElement)
   });
 })

--- a/__tests__/core.clone.more.test.js
+++ b/__tests__/core.clone.more.test.js
@@ -77,11 +77,17 @@ describe('deepClone – extra coverage', () => {
   warn.mockRestore()
 })
 
+it('exclude by selector with exclusionMode = "remove" skips element from clonning', async () => {
+  const el = document.createElement('div');
+  el.classList.add('exclude-me');
+  const out = await deepClone(el, session, { exclude: ['.exclude-me'], exclusionMode: 'remove' })
+  expect(out).not.toBeInstanceOf(HTMLElement)
+});
 
   it('excludes by custom filter returning false; and handles filter error', async () => {
     // filter false -> spacer
     const a = document.createElement('p')
-    const out1 = await deepClone(a, session, { filter: () => false })
+    const out1 = await deepClone(a, session, { filter: () => false, exclusionMode: 'visuallyHide' })
     expect(out1).toBeInstanceOf(HTMLElement)
     expect(out1.style.visibility).toBe('hidden')
 
@@ -92,7 +98,14 @@ describe('deepClone – extra coverage', () => {
     expect(out2).toBeInstanceOf(HTMLElement)
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
-  })
+  });
+
+  if ('custom filter with exclusionMode = "remove" skips element from clonning', async () => {
+    // filter false -> null
+    const a = document.createElement('p')
+    const out1 = await deepClone(a, session, { filter: () => false, exclusionMode: 'remove' })
+    expect(out1).not.toBeInstanceOf(HTMLElement)
+  });
 
   it('IFRAME fallback uses gradient style and element size', async () => {
     const frame = document.createElement('iframe')
@@ -186,6 +199,13 @@ describe('deepClone – extra coverage', () => {
     expect(txt.nodeType).toBe(Node.TEXT_NODE)
     expect(txt.nodeValue).toBe('slotted!')
   })
+
+  it('deepClone handles data-capture="exclude" with exclusionMode = "remove"', async () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-capture', 'exclude');
+    const out1 = await deepClone(el, session, { exclusionMode: 'remove' })
+    expect(out1).not.toBeInstanceOf(HTMLElement)
+  });
 })
 
 
@@ -487,7 +507,7 @@ describe('deepClone – extra targets to lift coverage', () => {
     expect(out.style.width).toBe('200px')
     expect(out.style.height).toBe('150px')
 
-    // 3) El <img> interno adopta el content-box (resta bordes): 
+    // 3) El <img> interno adopta el content-box (resta bordes):
     const img = out.querySelector('img')
     expect(img).toBeTruthy()
     expect(img.style.width).toBe('200px')

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -229,8 +229,8 @@ function buildSeedCustomPropsRule(hostEl, names, scopeSelector) {
 /**
  * Creates a deep clone of a DOM node, including styles, shadow DOM, and special handling for excluded/placeholder/canvas nodes.
  *
- * @param {Node} node - Node to clone 
- * @param {Object} [options={}] - Capture options including exclude and filter 
+ * @param {Node} node - Node to clone
+ * @param {Object} [options={}] - Capture options including exclude and filter
  * @param {Node} [originalRoot] - Original root element being captured
  * @returns {Node|null} Cloned node with styles and shadow DOM content, or null for empty text nodes or filtered elements
  */
@@ -376,19 +376,27 @@ export async function deepClone(node, sessionCache, options) {
     return node.cloneNode(true);
   }
   if (node.getAttribute("data-capture") === "exclude") {
-    const spacer = document.createElement("div");
-    const rect = node.getBoundingClientRect();
-    spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
-    return spacer;
+    if (options.exclusionMode === "visuallyHide") {
+      const spacer = document.createElement("div");
+      const rect = node.getBoundingClientRect();
+      spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
+      return spacer;
+    } else if (options.exclusionMode === "remove") {
+      return null;
+    }
   }
   if (options.exclude && Array.isArray(options.exclude)) {
     for (const selector of options.exclude) {
       try {
         if (node.matches?.(selector)) {
-          const spacer = document.createElement("div");
-          const rect = node.getBoundingClientRect();
-          spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
-          return spacer;
+          if (options.exclusionMode === "visuallyHide") {
+            const spacer = document.createElement("div");
+            const rect = node.getBoundingClientRect();
+            spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
+            return spacer;
+          } else if (options.exclusionMode === "remove") {
+            return null;
+          }
         }
       } catch (err) {
         console.warn(`Invalid selector in exclude option: ${selector}`, err);
@@ -398,10 +406,14 @@ export async function deepClone(node, sessionCache, options) {
   if (typeof options.filter === "function") {
     try {
       if (!options.filter(node)) {
-        const spacer = document.createElement("div");
-        const rect = node.getBoundingClientRect();
-        spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
-        return spacer;
+        if (options.exclusionMode === "visuallyHide") {
+          const spacer = document.createElement("div");
+          const rect = node.getBoundingClientRect();
+          spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
+          return spacer;
+        } else if (options.exclusionMode === "remove") {
+          return null;
+        }
       }
     } catch (err) {
       console.warn("Error in filter function:", err);

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -376,12 +376,12 @@ export async function deepClone(node, sessionCache, options) {
     return node.cloneNode(true);
   }
   if (node.getAttribute("data-capture") === "exclude") {
-    if (options.exclusionMode === "visuallyHide") {
+    if (options.excludeMode === "visuallyHide") {
       const spacer = document.createElement("div");
       const rect = node.getBoundingClientRect();
       spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
       return spacer;
-    } else if (options.exclusionMode === "remove") {
+    } else if (options.excludeMode === "remove") {
       return null;
     }
   }
@@ -389,12 +389,12 @@ export async function deepClone(node, sessionCache, options) {
     for (const selector of options.exclude) {
       try {
         if (node.matches?.(selector)) {
-          if (options.exclusionMode === "visuallyHide") {
+          if (options.excludeMode === "visuallyHide") {
             const spacer = document.createElement("div");
             const rect = node.getBoundingClientRect();
             spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
             return spacer;
-          } else if (options.exclusionMode === "remove") {
+          } else if (options.excludeMode === "remove") {
             return null;
           }
         }
@@ -406,12 +406,12 @@ export async function deepClone(node, sessionCache, options) {
   if (typeof options.filter === "function") {
     try {
       if (!options.filter(node)) {
-        if (options.exclusionMode === "visuallyHide") {
+        if (options.filterMode === "visuallyHide") {
           const spacer = document.createElement("div");
           const rect = node.getBoundingClientRect();
           spacer.style.cssText = `display:inline-block;width:${rect.width}px;height:${rect.height}px;visibility:hidden;`;
           return spacer;
-        } else if (options.exclusionMode === "remove") {
+        } else if (options.filterMode === "remove") {
           return null;
         }
       }

--- a/src/core/context.js
+++ b/src/core/context.js
@@ -24,8 +24,9 @@ export function normalizeCachePolicy(v) {
  * @param {boolean} [options.fast]
  * @param {number}  [options.scale]
  * @param {Array<string|RegExp>} [options.exclude]
+ * @param {string}  [options.excludeMode]
  * @param {(node: Node)=>boolean} [options.filter]
- * @param {string}  [options.exclusionMode]
+ * @param {string}  [options.filterMode]
  * @param {boolean} [options.embedFonts]
  * @param {string|string[]} [options.iconFonts]
  * @param {string[]} [options.localFonts]
@@ -56,8 +57,10 @@ export function createContext(options = {}) {
 
     // DOM filters
     exclude: options.exclude ?? [],
+    excludeMode: options.excludeMode ?? 'visuallyHide',
     filter: options.filter ?? null,
-    exclusionMode: options.exclusionMode ?? 'visuallyHide',
+    filterMode: options.filterMode ?? 'visuallyHide',
+
     placeholders: options.placeholders !== false, // default true
 
     // Fuentes

--- a/src/core/context.js
+++ b/src/core/context.js
@@ -25,6 +25,7 @@ export function normalizeCachePolicy(v) {
  * @param {number}  [options.scale]
  * @param {Array<string|RegExp>} [options.exclude]
  * @param {(node: Node)=>boolean} [options.filter]
+ * @param {string}  [options.exclusionMode]
  * @param {boolean} [options.embedFonts]
  * @param {string|string[]} [options.iconFonts]
  * @param {string[]} [options.localFonts]
@@ -56,6 +57,7 @@ export function createContext(options = {}) {
     // DOM filters
     exclude: options.exclude ?? [],
     filter: options.filter ?? null,
+    exclusionMode: options.exclusionMode ?? 'visuallyHide',
     placeholders: options.placeholders !== false, // default true
 
     // Fuentes

--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -13,7 +13,8 @@ export type BlobType = "svg" | RasterMime;
 export type IconFontMatcher = string | RegExp;
 export type CachePolicy = "disabled" | "full" | "auto" | "soft";
 
-export type ExclusionMode = 'visuallyHide' | 'remove';
+export type ExcludeMode = 'visuallyHide' | 'remove';
+export type FilterMode = 'visuallyHide' | 'remove';
 
 export interface LocalFontDescriptor {
   /** CSS font-family name (e.g. "Inter"). */
@@ -90,16 +91,22 @@ export interface CaptureOptions {
   exclude?: string[];
 
   /**
+   * Mode applied to excluded nodes of the cloned tree.
+   * Default: "visuallyHide"
+   */
+  excludeMode?: ExcludeMode;
+
+  /**
    * Advanced node filter; return false to exclude a node during traversal.
    * Applied to the cloned subtree.
    */
   filter?: (el: Element) => boolean;
 
   /**
-   * Mode applied to excluded or filtered nodes of the cloned tree.
+   * Mode applied to filtered nodes of the cloned tree.
    * Default: "visuallyHide"
    */
-  exclusionMode?: ExclusionMode;
+  filterMode?: FilterMode;
 
   /**
    * Whether to synthesize placeholders for broken images, etc.

--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -13,6 +13,8 @@ export type BlobType = "svg" | RasterMime;
 export type IconFontMatcher = string | RegExp;
 export type CachePolicy = "disabled" | "full" | "auto" | "soft";
 
+export type ExclusionMode = 'visuallyHide' | 'remove';
+
 export interface LocalFontDescriptor {
   /** CSS font-family name (e.g. "Inter"). */
   family: string;
@@ -92,6 +94,12 @@ export interface CaptureOptions {
    * Applied to the cloned subtree.
    */
   filter?: (el: Element) => boolean;
+
+  /**
+   * Mode applied to excluded or filtered nodes of the cloned tree.
+   * Default: "visuallyHide"
+   */
+  exclusionMode?: ExclusionMode;
 
   /**
    * Whether to synthesize placeholders for broken images, etc.


### PR DESCRIPTION
Added **exclusionMode** with two possible values **visuallyHide** and **remove** that controls how `exclude` and `filter` options work.

visuallyHide - current behavior. Adding `visibility:hidden` to cloned element
remove - do not clone node at all.

Closes https://github.com/zumerlab/snapdom/issues/227
