### PR TITLE
fix: improve CSS src property parsing in font faces

### DIFF
--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -432,7 +432,7 @@ function dedupeFontFaces(cssText) {
     const styleSpec = (block.match(/font-style:\s*([^;]+);/i)?.[1] || 'normal').trim()
     const stretchSpec = (block.match(/font-stretch:\s*([^;]+);/i)?.[1] || '100%').trim()
     const urange = (block.match(/unicode-range:\s*([^;]+);/i)?.[1] || '').trim()
-    const srcRaw = (block.match(/src\s*:\s*([^;]+);/i)?.[1] || '').trim()
+    const srcRaw = (block.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || '').trim()
 
     const urls = extractSrcUrls(srcRaw, location.href)
     const srcPart = urls.length
@@ -720,7 +720,7 @@ export async function embedCustomFonts({
         const styleSpec = (face.match(/font-style:\s*([^;]+);/i)?.[1] || 'normal').trim()
         const stretchSpec = (face.match(/font-stretch:\s*([^;]+);/i)?.[1] || '100%').trim()
         const urange = (face.match(/unicode-range:\s*([^;]+);/i)?.[1] || '').trim()
-        const srcRaw = (face.match(/src\s*:\s*([^;]+);/i)?.[1] || '').trim()
+        const srcRaw = (face.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || '').trim()
         const srcUrls = extractSrcUrls(srcRaw, link.href)
 
         if (!faceMatchesRequired(family, styleSpec, weightSpec, stretchSpec)) continue


### PR DESCRIPTION
- Fix regex pattern to handle src properties ending with } instead of ;
- Update both dedupeFontFaces and embedCustomFonts functions;


In production builds, some bundlers and minification tools remove trailing semicolons from CSS properties, causing font parsing to fail. This results in generated images not displaying the correct fonts.

Example 
```
/* Original CSS */
@font-face {
  font-family: SourceHanSansSC-Regular;
  src: url('@/assets/fonts/SourceHanSansSC-Regular.ttf') format('truetype');
}

/* After minification */
@font-face{font-family:SourceHanSansSC-Regular;src:url(//cdn.com/SourceHanSansSC-Regular-BGsZiTxe.ttf) format("truetype")}

```

All tests passed！