### PR TITLE
Modify README example to use overlayFilterPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,10 +497,10 @@ For each export key you return (e.g., `"pdf"`), SnapDOM automatically exposes a 
 import { snapdom } from '@zumer/snapdom';
 
 // global
-snapdom.plugins(pdfExportPlugin());
+snapdom.plugins(overlayFilterPlugin());
 
 // or per capture
-const out = await snapdom(element, { plugins: [pdfExportPlugin()] });
+const out = await snapdom(element, { plugins: [overlayFilterPlugin()] });
 ```
 
 **Call the custom export:**


### PR DESCRIPTION
Updated example code to use overlayFilterPlugin instead of pdfExportPlugin.