### PR TITLE
Fix: Inherit root font-size in SVG output

### DIFF
--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -289,7 +289,8 @@ try {
         ? vbH
         : limitDecimals(outH + pad * 2)
 
-      const svgHeader = `<svg xmlns="${svgNS}" width="${svgOutW}" height="${svgOutH}" viewBox="0 0 ${vbW} ${vbH}">`
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16
+      const svgHeader = `<svg xmlns="${svgNS}" width="${svgOutW}" height="${svgOutH}" viewBox="0 0 ${vbW} ${vbH}" font-size="${rootFontSize}px">`
       const svgFooter = '</svg>'
       svgString = svgHeader + foString + svgFooter
       dataURL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`


### PR DESCRIPTION
Image elements with dimensions specified in rem units were not rendered at the correct size in the generated SVG. This occurred because the SVG did not inherit the document's root font-size, causing the browser to use the default 16px instead of the actual root font-size.

This fix ensures that all elements using rem units (images, text, borders, etc.) are rendered at the correct size, matching the original document's appearance.

