### PR TITLE
fix(background): inline background-image inside shadow DOM hosts

### DIFF
--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -86,6 +86,9 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
 
   while (queue.length) {
     const [srcNode, cloneNode] = queue.shift()
+
+    if (!cloneNode) continue
+
     // Style cache
     const style = styleCache.get(srcNode) || getStyle(srcNode)
     if (!styleCache.has(srcNode)) styleCache.set(srcNode, style)
@@ -104,6 +107,7 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
     for (const prop of URL_PROPS) {
       const val = style.getPropertyValue(prop)
       if (!val || val === 'none') continue
+
       // Split multiple layers (comma-separated)
       const splits = splitBackgroundImage(val)
 
@@ -131,9 +135,20 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
       }
     }
     // 4) Recurse
-    const sChildren = Array.from(srcNode.children)
- const cChildren = Array.from(cloneNode.children)
-   .filter(el => !(el.dataset && el.dataset.snapdomPseudo))
+    // Fix: When srcNode is a shadow DOM host, its light DOM children are empty
+    // (content lives in shadowRoot). Use shadowRoot.children instead, filtering
+    // out <style> elements which are skipped during shadow DOM cloning.
+    const sChildren = srcNode.shadowRoot
+      ? Array.from(srcNode.shadowRoot.children).filter(el => el.tagName !== 'STYLE')
+      : Array.from(srcNode.children)
+    const cChildren = Array.from(cloneNode.children)
+      .filter(el => {
+        if (el.dataset?.snapdomPseudo) return false
+        // Only exclude injected <style data-sd> tags, not shadow DOM host elements
+        if (el.tagName === 'STYLE' && el.dataset?.sd) return false
+        return true
+      })
+
     for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
       queue.push([sChildren[i], cChildren[i]])
     }


### PR DESCRIPTION
When a custom element uses a shadow root with `background-image`, snapdom would silently skip the shadow subtree during the background inlining phase, leaving images blank in the captured output.

Closes #318

## Root cause

Two bugs worked together:

**1. `sChildren` always used the light DOM**

`inlineBackgroundImages` reads `srcNode.children` to recurse into child elements. For shadow hosts whose content lives entirely inside `shadowRoot` (no light DOM), this returns an empty NodeList — the recursion never reaches the shadow tree.

Fix: fall back to `srcNode.shadowRoot.children` when a shadowRoot is present, mirroring what `clone.js` already does.

**2. Overly broad `data-sd` filter on `cChildren`**

`clone.js` sets a `data-sd` attribute on the cloned shadow host for CSS scoping. The `cChildren` filter was excluding *every* element with `data-sd`, so the cloned host itself got dropped even after fix 1, leaving `cChildren` empty again.

Fix: tighten the predicate to only exclude injected `<style data-sd>` tags, not regular host elements that carry `data-sd`.

Also adds a null-guard (`if (!cloneNode) continue`) to prevent a crash when the clone walk returns `null` for an excluded or uncloneable node.