### PR TITLE
fix: use nodeMap for source-clone alignment in inlinePseudoElements

### DIFF
--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -592,10 +592,21 @@ const hasExplicitContent = !isNoExplicitContent && cleanContent !== ''
     }
   }
 
-  // Recurse
-  const sChildren = Array.from(source.children)
+  // Recurse – use nodeMap (clone→source) for alignment instead of index,
+  // because deepClone filters out NO_CAPTURE_TAGS (script, link, etc.),
+  // which causes index mismatch between source.children and clone.children.
   const cChildren = Array.from(clone.children).filter((child) => !child.dataset.snapdomPseudo)
-  for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
-    await inlinePseudoElements(sChildren[i], cChildren[i], sessionCache, options)
+  if (sessionCache.nodeMap) {
+    for (const cChild of cChildren) {
+      const sChild = sessionCache.nodeMap.get(cChild)
+      if (sChild instanceof Element) {
+        await inlinePseudoElements(sChild, cChild, sessionCache, options)
+      }
+    }
+  } else {
+    const sChildren = Array.from(source.children)
+    for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
+      await inlinePseudoElements(sChildren[i], cChildren[i], sessionCache, options)
+    }
   }
 }


### PR DESCRIPTION

## Problem

When capturing `document.body` (or any element whose direct children include `<script>`, `<link>`, `<noscript>`, etc.), pseudo-element content such as Font Awesome icon glyphs rendered via `::before` fails to appear in the output.

### Root Cause

`deepClone` filters out `NO_CAPTURE_TAGS` (`script`, `link`, `noscript`, `meta`, `title`, `template`) by returning `null`, so they are excluded from the clone tree. However, `inlinePseudoElements` pairs source and clone children **by array index**:

```js
const sChildren = Array.from(source.children)
const cChildren = Array.from(clone.children).filter(...)
for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
    await inlinePseudoElements(sChildren[i], cChildren[i], ...)
}
```

When the source has filtered-out tags interspersed among real content elements, the indices diverge — each clone child gets paired with the **wrong** source element (often a `<script>`), so `getComputedStyle(source, '::before')` returns nothing meaningful and icon font detection silently fails.

For example, a typical `document.body` might have 24 direct children with 21 being `<script>`/`<link>` tags. After filtering, only 3 clone children remain, all paired with `<script>` sources instead of their actual counterparts.

### Why capturing a deeper element works

Targeting a deeper element that has no `NO_CAPTURE_TAGS` among its direct children avoids the index mismatch entirely, which is why the same page captures icon fonts correctly when a narrower target is used.

## Fix

Use `sessionCache.nodeMap` (the clone→source mapping already built by `deepClone`) to look up the correct source element for each clone child, instead of relying on positional index alignment. Falls back to index-based matching when `nodeMap` is unavailable.

## Verification

- All 284 existing tests pass (35 test files).
- Manually verified on a page with Font Awesome icons: capturing `document.body` now correctly renders all icon glyphs via `::before` pseudo-elements (previously blank).

