### PR TITLE
fix(toCanvas): fix intermittent blank images in raster exports

### DIFF
--- a/src/exporters/toCanvas.js
+++ b/src/exporters/toCanvas.js
@@ -138,6 +138,15 @@ export async function toCanvas(url, options) {
   img.src = url
   await img.decode()
 
+  // img.decode() only guarantees the outer SVG element is decoded, not that
+  // <img> elements nested inside <foreignObject> have been composited by the
+  // browser. Attaching the image to the document and waiting two animation
+  // frames gives the compositing pipeline time to finish rendering inner images.
+  img.style.cssText = 'position:fixed;left:-99999px;top:-99999px;pointer-events:none;'
+  document.body.appendChild(img)
+  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
+  document.body.removeChild(img)
+
   const natW = img.naturalWidth
   const natH = img.naturalHeight
 

--- a/src/exporters/toCanvas.js
+++ b/src/exporters/toCanvas.js
@@ -124,11 +124,12 @@ function maybeConvertBoxShadowForSafari(url) {
  *   dpr?:number,
  *   meta?:object,
  *   backgroundColor?: string // <- NUEVO: color opcional para aplanar fondo
+ *   waitForCompositing?: boolean  // wait two rAFs after decode to ensure <img> inside foreignObject are composited (default: false)
  * }} options
  * @returns {Promise<HTMLCanvasElement>}
  */
 export async function toCanvas(url, options) {
-  let { width: optW, height: optH, scale = 1, dpr = 1, meta = {}, backgroundColor } = options
+  let { width: optW, height: optH, scale = 1, dpr = 1, meta = {}, backgroundColor, waitForCompositing = false } = options
   url = maybeConvertBoxShadowForSafari(url)
 
   const img = new Image()
@@ -138,14 +139,16 @@ export async function toCanvas(url, options) {
   img.src = url
   await img.decode()
 
-  // img.decode() only guarantees the outer SVG element is decoded, not that
-  // <img> elements nested inside <foreignObject> have been composited by the
-  // browser. Attaching the image to the document and waiting two animation
-  // frames gives the compositing pipeline time to finish rendering inner images.
-  img.style.cssText = 'position:fixed;left:-99999px;top:-99999px;pointer-events:none;'
-  document.body.appendChild(img)
-  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
-  document.body.removeChild(img)
+  if (waitForCompositing) {
+    // img.decode() only guarantees the outer SVG element is decoded, not that
+    // <img> elements nested inside <foreignObject> have been composited by the
+    // browser. Attaching the image to the document and waiting two animation
+    // frames gives the compositing pipeline time to finish rendering inner images.
+    img.style.cssText = 'position:fixed;left:-99999px;top:-99999px;pointer-events:none;'
+    document.body.appendChild(img)
+    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
+    document.body.removeChild(img)
+  }
 
   const natW = img.naturalWidth
   const natH = img.naturalHeight

--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -109,6 +109,14 @@ export interface SnapdomOptions {
   /** Show placeholders when resources are missing. Default true. */
   placeholders?: boolean;
 
+  /**
+   * Wait two animation frames after `img.decode()` before drawing to canvas,
+   * giving the browser's compositing pipeline time to render `<img>` elements
+   * nested inside `<foreignObject>`. Set to `true` when the captured element
+   * contains images to avoid intermittent blank image bugs. Default `false`.
+   */
+  waitForCompositing?: boolean;
+
   /** Arbitrary plugin configuration at call-site (see PluginUse). */
   plugins?: PluginUse[];
 }


### PR DESCRIPTION


  # Problem

  When exporting to raster formats (PNG, JPEG, WebP etc.), images inside the
  captured element intermittently appear blank or missing.

  Root cause: img.decode() only guarantees the outer SVG wrapper is decoded — it
  does not guarantee that <img> elements nested inside <foreignObject> have been
  composited by the browser. When drawImage() is called immediately after
  decode(), the browser may not have finished rendering inner images, producing a
   blank result non-deterministically.

  # Solution

  After img.decode(), attach the SVG image to the document outside the viewport
  (position:fixed; left:-99999px; top:-99999px) and wait two
  requestAnimationFrame callbacks before calling drawImage(). This gives the
  browser's compositing pipeline enough time to finish rendering all inner
  images.

  To avoid the performance overhead in captures that don't contain images, the
  behavior is opt-in via a new waitForCompositing option (default: false).

  // Captures with <img> elements — enable compositing wait
  snapdom.toPng(element, { waitForCompositing: true })

close #394 