### PR TITLE
Add Umami analytics events to all navigation links

### DIFF
--- a/docs/compare/dom-to-image/index.html
+++ b/docs/compare/dom-to-image/index.html
@@ -253,12 +253,12 @@ document.body.<span class="fn">appendChild</span>(img);</pre>
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../" class="current">Compare</a>
-    <a href="../../guides/">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../" class="current" data-umami-event="Nav compare">Compare</a>
+    <a href="../../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/compare/html-to-image/index.html
+++ b/docs/compare/html-to-image/index.html
@@ -251,12 +251,12 @@ document.body.<span class="fn">appendChild</span>(img);</pre>
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../" class="current">Compare</a>
-    <a href="../../guides/">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../" class="current" data-umami-event="Nav compare">Compare</a>
+    <a href="../../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/compare/html2canvas/index.html
+++ b/docs/compare/html2canvas/index.html
@@ -278,12 +278,12 @@ document.body.<span class="fn">appendChild</span>(img);</pre>
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../" class="current">Compare</a>
-    <a href="../../guides/">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../" class="current" data-umami-event="Nav compare">Compare</a>
+    <a href="../../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/compare/index.html
+++ b/docs/compare/index.html
@@ -98,12 +98,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../">Showcase</a>
-    <a href="../plugins.html">Plugins</a>
-    <a href="./" class="current">Compare</a>
-    <a href="../guides/">Guides</a>
-    <a href="../how-to/">How-to</a>
-    <a href="../labs.html">Labs</a>
+    <a href="../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="./" class="current" data-umami-event="Nav compare">Compare</a>
+    <a href="../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -98,12 +98,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../">Showcase</a>
-    <a href="../plugins.html">Plugins</a>
-    <a href="../compare/">Compare</a>
-    <a href="./" class="current">Guides</a>
-    <a href="../how-to/">How-to</a>
-    <a href="../labs.html">Labs</a>
+    <a href="../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="./" class="current" data-umami-event="Nav guides">Guides</a>
+    <a href="../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/guides/nextjs/index.html
+++ b/docs/guides/nextjs/index.html
@@ -245,12 +245,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../../compare/">Compare</a>
-    <a href="../" class="current">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../" class="current" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/guides/react/index.html
+++ b/docs/guides/react/index.html
@@ -261,12 +261,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../../compare/">Compare</a>
-    <a href="../" class="current">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../" class="current" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/guides/vue/index.html
+++ b/docs/guides/vue/index.html
@@ -245,12 +245,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../../compare/">Compare</a>
-    <a href="../" class="current">Guides</a>
-    <a href="../../how-to/">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../" class="current" data-umami-event="Nav guides">Guides</a>
+    <a href="../../how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/how-to/html-to-png/index.html
+++ b/docs/how-to/html-to-png/index.html
@@ -250,12 +250,12 @@ form.<span class="fn">append</span>(<span class="str">'file'</span>, blob, <span
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../../compare/">Compare</a>
-    <a href="../../guides/">Guides</a>
-    <a href="../" class="current">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../" class="current" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/how-to/index.html
+++ b/docs/how-to/index.html
@@ -92,12 +92,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="../">Showcase</a>
-    <a href="../plugins.html">Plugins</a>
-    <a href="../compare/">Compare</a>
-    <a href="../guides/">Guides</a>
-    <a href="./" class="current">How-to</a>
-    <a href="../labs.html">Labs</a>
+    <a href="../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="./" class="current" data-umami-event="Nav how-to">How-to</a>
+    <a href="../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/how-to/screenshot-a-div/index.html
+++ b/docs/how-to/screenshot-a-div/index.html
@@ -266,12 +266,12 @@ form.<span class="fn">append</span>(<span class="str">'file'</span>, blob, <span
   </main>
 
   <nav class="page-nav">
-    <a href="../../">Showcase</a>
-    <a href="../../plugins.html">Plugins</a>
-    <a href="../../compare/">Compare</a>
-    <a href="../../guides/">Guides</a>
-    <a href="../" class="current">How-to</a>
-    <a href="../../labs.html">Labs</a>
+    <a href="../../" data-umami-event="Nav showcase">Showcase</a>
+    <a href="../../plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="../../compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="../../guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="../" class="current" data-umami-event="Nav how-to">How-to</a>
+    <a href="../../labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2015,12 +2015,12 @@
   </script>
 
   <nav class="page-nav">
-    <a href="./index.html" class="current">Showcase</a>
-    <a href="./plugins.html">Plugins</a>
-    <a href="./compare/">Compare</a>
-    <a href="./guides/">Guides</a>
-    <a href="./how-to/">How-to</a>
-    <a href="./labs.html">Labs</a>
+    <a href="./index.html" class="current" data-umami-event="Nav showcase">Showcase</a>
+    <a href="./plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="./compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="./guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="./how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="./labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <script>

--- a/docs/labs.html
+++ b/docs/labs.html
@@ -160,12 +160,12 @@
   </main>
 
   <nav class="page-nav">
-    <a href="./index.html">Showcase</a>
-    <a href="./plugins.html">Plugins</a>
-    <a href="./compare/">Compare</a>
-    <a href="./guides/">Guides</a>
-    <a href="./how-to/">How-to</a>
-    <a href="./labs.html" class="current">Labs</a>
+    <a href="./index.html" data-umami-event="Nav showcase">Showcase</a>
+    <a href="./plugins.html" data-umami-event="Nav plugins">Plugins</a>
+    <a href="./compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="./guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="./how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="./labs.html" class="current" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <!-- Theme toggle -->

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -561,12 +561,12 @@
   <!-- ── Scripts ── -->
 
   <nav class="page-nav">
-    <a href="./index.html" data-umami-event="Plugins nav showcase">Showcase</a>
-    <a href="./plugins.html" class="current">Plugins</a>
-    <a href="./compare/" data-umami-event="Plugins nav compare">Compare</a>
-    <a href="./guides/" data-umami-event="Plugins nav guides">Guides</a>
-    <a href="./how-to/" data-umami-event="Plugins nav howto">How-to</a>
-    <a href="./labs.html" data-umami-event="Plugins nav labs">Labs</a>
+    <a href="./index.html" data-umami-event="Nav showcase">Showcase</a>
+    <a href="./plugins.html" class="current" data-umami-event="Nav plugins">Plugins</a>
+    <a href="./compare/" data-umami-event="Nav compare">Compare</a>
+    <a href="./guides/" data-umami-event="Nav guides">Guides</a>
+    <a href="./how-to/" data-umami-event="Nav how-to">How-to</a>
+    <a href="./labs.html" data-umami-event="Nav labs">Labs</a>
   </nav>
 
   <!-- Theme toggle -->


### PR DESCRIPTION
- Added data-umami-event attributes to all page-nav links across all HTML files
- Ensures proper event tracking for navigation in all sections (guides, compare, how-to)
- Fixed missing navigation event tracking in React guide and other sub-pages
- All 14 HTML files now have consistent Umami and Google Analytics configuration

https://claude.ai/code/session_01CE9PauqtrUCtnWCDPsvWSM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds `data-umami-event` attributes to navigation links; potential impact is limited to analytics tracking (and only if event names are relied on downstream).
> 
> **Overview**
> Adds consistent Umami navigation tracking by attaching `data-umami-event` attributes to all `nav.page-nav` links across the docs site (showcase, plugins, compare, guides, how-to, labs), including compare subpages and framework/how-to pages.
> 
> Also standardizes previously page-specific event names (notably on `docs/plugins.html`) to a shared `Nav …` naming scheme for uniform reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68cbac6380207965e9f9a0ededc121ea78bafa4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->