### PR TITLE
Fix download format option types

### DIFF
--- a/types/snapdom.d.ts
+++ b/types/snapdom.d.ts
@@ -58,6 +58,8 @@ export interface SnapdomOptions {
   backgroundColor?: string;
   /** Quality for JPEG/WebP (0..1). Default 1. */
   quality?: number;
+  /** Output format for capture/export helpers. Default "png". */
+  format?: BlobType;
 
   /** Cross-origin proxy prefix (used as a fallback when CORS blocks). */
   useProxy?: string;
@@ -214,6 +216,8 @@ export type PluginUse =
 
 export interface DownloadOptions {
   filename?: string;
+  /** Output format for the downloaded file. Default "png". */
+  format?: BlobType;
   /** Override default blob type for this download. */
   type?: BlobType;
   /** Quality hint for raster formats. */


### PR DESCRIPTION
## Summary
- Add the missing `format` option to the public TypeScript declarations for capture and download options.
- Keep the type constrained to the existing `BlobType` formats: `svg`, `png`, `jpg`, `jpeg`, and `webp`.

Fixes #416

## Tests
- Reproduced the pre-fix TS2353 error with a strict temporary TSX fixture calling `result.download({ format: 'jpg', filename: 'print.jpg' })`.
- `npm_config_cache=/Users/deepakkudi23/ai-resume-contrib-100/snapdom/.npm-cache npx -y -p typescript tsc --noEmit --strict --jsx react-jsx --target ES2020 --module ESNext --moduleResolution bundler --lib DOM,ES2020 <temporary fixture>`
- `git diff --check`