### PR TITLE
Fix for placeholder colors not being copied over on webkit browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,6 @@ drafts/
 
 demos/
 
-__tests__/__screenshots__
 __snapshots__
 
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ __snapshots__
 .cursor/
 bench/
 AGENTS.md
+__tests__/__screenshots__/

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ drafts/
 
 demos/
 
+__tests__/__screenshots__
 __snapshots__
 
 .vscode/
@@ -148,4 +149,3 @@ __snapshots__
 .cursor/
 bench/
 AGENTS.md
-__tests__/__screenshots__/

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -345,7 +345,7 @@ export async function deepClone(node, sessionCache, options) {
     }
   }
 
-  // #315: Preserve placeholder for inputs/textareas showing placeholder text
+  // #315: Preserve ::placeholder color for inputs/textareas showing placeholder text
   if ((node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement) && !node.value && node.placeholder) {
     try {
       const phStyle = window.getComputedStyle(node, '::placeholder')

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -344,7 +344,8 @@ export async function deepClone(node, sessionCache, options) {
       }
     }
   }
-  // #315: Preserve ::placeholder color for inputs/textareas showing placeholder text
+
+  // #315: Preserve placeholder for inputs/textareas showing placeholder text
   if ((node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement) && !node.value && node.placeholder) {
     try {
       const phStyle = window.getComputedStyle(node, '::placeholder')
@@ -353,11 +354,12 @@ export async function deepClone(node, sessionCache, options) {
         const uid = 'snapdom-ph-' + (Math.random() * 1e6 | 0)
         clone.classList.add(uid)
         const styleEl = document.createElement('style')
-        styleEl.textContent = `.${uid}::placeholder{color:${phColor}!important;opacity:${phStyle.opacity || '1'}!important;}`
+        styleEl.textContent = `.${uid}::placeholder{color:${phColor}!important;opacity:${phStyle.opacity || '1'}!important;-webkit-text-fill-color:${phColor}!important;}`
         clone.prepend(styleEl)
       }
     } catch { /* non-blocking */ }
   }
+
   if (node instanceof HTMLSelectElement) {
     pendingSelectValue = node.value
   }
@@ -490,7 +492,6 @@ export async function deepClone(node, sessionCache, options) {
   }
   if (pendingTextAreaValue !== null && clone instanceof HTMLTextAreaElement) {
     clone.textContent = pendingTextAreaValue
-
   }
   return clone
 }


### PR DESCRIPTION
On Chrome specifically I am still seing black placeholders, they are not showing the styles I have given them

Reproduction example:
https://codepen.io/editor/pdufour/pen/019e637f-3d21-78b1-a372-9584b474aa5f

<img width="220" height="135" alt="image" src="https://github.com/user-attachments/assets/6e0fd04f-61a9-4980-8dd2-de17ea3547ea" />


Now with my fix:
<img width="210" height="153" alt="image" src="https://github.com/user-attachments/assets/d66a747a-bed5-431d-a55a-1a6dd1eb8c5d" />


