### PR TITLE
fix: correctness, fidelity, perf & dead-code fixes from multi-agent audit

### DIFF
--- a/__tests__/api.preCache.test.js
+++ b/__tests__/api.preCache.test.js
@@ -50,8 +50,9 @@ describe('preCache – extra coverage', () => {
   // (2) Con proxy activo, NO hay intentos directos en el nuevo snapFetch
   expect(directCalls.length).toBe(0)
 
-  // (3) Dedupe en cache.background: una sola entrada para ese URL
-  const key = safeEncodeURI(DIRECT)
+  // (3) Dedupe en cache.background: una sola entrada para ese URL.
+  // La clave incluye el proxy (evita que un fallo sin-proxy envenene otra config).
+  const key = PROXY + '|' + safeEncodeURI(DIRECT)
   expect(cache.background.has(key)).toBe(true)
   expect([...cache.background.keys()].filter(k => k === key).length).toBe(1)
 
@@ -78,7 +79,8 @@ describe('preCache – extra coverage', () => {
     await preCache(el)
 
     // Verificamos que SOLO la capa url(...) fue procesada y quedó cacheada
-    const key = safeEncodeURI(URL)
+    // (clave con prefijo de proxy vacío, sin useProxy)
+    const key = '|' + safeEncodeURI(URL)
     expect(cache.background.has(key)).toBe(true)
 
     // No exigimos conteo de fetch: puede ser 0 si fuese raster.
@@ -105,8 +107,8 @@ describe('preCache – extra coverage', () => {
 
     await preCache(root)
 
-    // Comprobamos que el hijo fue visto y cacheado
-    const key = safeEncodeURI(CHILD_URL)
+    // Comprobamos que el hijo fue visto y cacheado (clave con prefijo de proxy vacío)
+    const key = '|' + safeEncodeURI(CHILD_URL)
     expect(cache.background.has(key)).toBe(true)
 
     document.body.removeChild(root)

--- a/__tests__/core.cache.test.js
+++ b/__tests__/core.cache.test.js
@@ -13,6 +13,7 @@ function snapshotRefs() {
     defaultStyle: cache.defaultStyle,
     baseStyle: cache.baseStyle,
     computedStyle: cache.computedStyle,
+    measureHints: cache.measureHints,
     font: cache.font,
     session_styleMap: cache.session.styleMap,
     session_styleCache: cache.session.styleCache,
@@ -27,6 +28,7 @@ function seedSomeData() {
   cache.defaultStyle.set('d', 4)
   cache.baseStyle.set('bs', 5)
   cache.computedStyle.set({}, { c: 6 })
+  cache.measureHints.set({}, { cssLen: 1, w0: 2, csh: 3, csw: 4 })
   cache.font.add('Inter__400')
   cache.session.styleMap.set('x', 'y')
   cache.session.styleCache.set({}, { sc: 1 })
@@ -57,6 +59,7 @@ describe('applyCachePolicy', () => {
     cache.defaultStyle = new Map()
     cache.baseStyle = new Map()
     cache.computedStyle = new WeakMap()
+    cache.measureHints = new WeakMap()
     cache.font = new Set()
     cache.session.styleMap = new Map()
     cache.session.styleCache = new WeakMap()
@@ -152,6 +155,7 @@ describe('applyCachePolicy', () => {
     expect(after.defaultStyle).not.toBe(before.defaultStyle)
     expect(after.baseStyle).not.toBe(before.baseStyle)
     expect(after.computedStyle).not.toBe(before.computedStyle)
+    expect(after.measureHints).not.toBe(before.measureHints)
     expect(after.font).not.toBe(before.font)
     expect(after.session_styleMap).not.toBe(before.session_styleMap)
     expect(after.session_styleCache).not.toBe(before.session_styleCache)

--- a/__tests__/core.prepare.test.js
+++ b/__tests__/core.prepare.test.js
@@ -106,6 +106,38 @@ describe('prepareClone deep coverage (Browser Mode)', () => {
     await expect(prepareClone(el)).resolves.toBeTruthy()
   })
 
+  it('inlines external SVG defs into the clone without mutating the source DOM', async () => {
+    const SVG_NS = 'http://www.w3.org/2000/svg'
+    // External symbol living elsewhere in the document.
+    const gsvg = document.createElementNS(SVG_NS, 'svg')
+    const sym = document.createElementNS(SVG_NS, 'symbol')
+    sym.setAttribute('id', 'ext-star')
+    sym.appendChild(document.createElementNS(SVG_NS, 'path'))
+    gsvg.appendChild(sym)
+    document.body.appendChild(gsvg)
+
+    // Source references the external symbol via <use>.
+    const src = document.createElement('div')
+    const svg = document.createElementNS(SVG_NS, 'svg')
+    const use = document.createElementNS(SVG_NS, 'use')
+    use.setAttribute('href', '#ext-star')
+    svg.appendChild(use)
+    src.appendChild(svg)
+    document.body.appendChild(src)
+
+    const { clone } = await prepareClone(src)
+
+    // Live source must be left untouched (non-destructive capture).
+    expect(src.querySelector('svg.inline-defs-container')).toBeNull()
+    // The clone carries the inlined defs so the serialized SVG resolves the <use>.
+    const container = clone.querySelector('svg.inline-defs-container')
+    expect(container).toBeTruthy()
+    expect(container.querySelector('symbol#ext-star')).toBeTruthy()
+
+    src.remove()
+    gsvg.remove()
+  })
+
   it('handles error in inlinePseudoElements (logs and continues)', async () => {
     const el = document.createElement('div')
     vi.mocked(pseudo.inlinePseudoElements).mockImplementationOnce(() => {

--- a/__tests__/module.counter.test.js
+++ b/__tests__/module.counter.test.js
@@ -2,11 +2,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
   hasCounters,
-  unquoteDoubleStrings,
   buildCounterContext,
-  resolveCountersInContent,
-  deriveCounterCtxForPseudo,
-  resolvePseudoContent
+  resolveCountersInContent
 } from '../src/modules/counter.js'
 
 beforeEach(() => {
@@ -30,17 +27,6 @@ describe('hasCounters', () => {
     expect(hasCounters('content: "foo"')).toBe(false)
     expect(hasCounters('')).toBe(false)
     expect(hasCounters(null)).toBe(false)
-  })
-})
-
-describe('unquoteDoubleStrings', () => {
-  it('removes double quotes from strings', () => {
-    expect(unquoteDoubleStrings('"hello"')).toBe('hello')
-    expect(unquoteDoubleStrings('before "mid" after')).toBe('before mid after')
-  })
-  it('handles null/empty', () => {
-    expect(unquoteDoubleStrings(null)).toBe('')
-    expect(unquoteDoubleStrings('')).toBe('')
   })
 })
 
@@ -121,30 +107,6 @@ describe('resolveCountersInContent', () => {
     document.body.appendChild(root)
     const ctx = buildCounterContext(root)
     expect(resolveCountersInContent('counters(x, ". ")', inner, ctx)).toBe('2')
-  })
-})
-
-describe('deriveCounterCtxForPseudo', () => {
-  it('applies pseudo counter-reset/increment', () => {
-    const span = document.createElement('span')
-    span.style.counterReset = 'item 0'
-    document.body.appendChild(span)
-    const baseCtx = buildCounterContext(span)
-    const pseudoStyle = {
-      counterReset: 'item 5',
-      counterIncrement: 'item'
-    }
-    const derived = deriveCounterCtxForPseudo(span, pseudoStyle, baseCtx)
-    expect(derived.get(span, 'item')).toBe(6)
-  })
-})
-
-describe('resolvePseudoContent', () => {
-  it('returns empty for none/normal', () => {
-    const span = document.createElement('span')
-    document.body.appendChild(span)
-    const ctx = buildCounterContext(span)
-    expect(resolvePseudoContent(span, '::before', ctx)).toBe('')
   })
 })
 

--- a/__tests__/module.fonts.more.test.js
+++ b/__tests__/module.fonts.more.test.js
@@ -193,7 +193,7 @@ describe('embedCustomFonts - cache hits & fetch errors', () => {
 
 /* ----------------- @import injection & dedupe ------------------ */
 describe('embedCustomFonts - @import injection & dedupe', () => {
-  it('injects <link rel="stylesheet"> for @import urls and does not duplicate', async () => {
+  it('reaches @import urls via a temporary <link> that is removed afterwards (non-destructive)', async () => {
     const imported = 'https://fonts.googleapis.com/css2?family=Inter:wght@400'
     addStyle(`@import url("${imported}");`)
 
@@ -220,9 +220,10 @@ describe('embedCustomFonts - @import injection & dedupe', () => {
       usedCodepoints: cps('A'),
     })
 
+    // The temporary <link> injected to reach the @import must be gone afterwards: the
+    // capture collected the font CSS but left the user's <head> untouched (#non-destructive).
     const links = [...document.querySelectorAll(`link[rel="stylesheet"][href="${imported}"]`)]
-    expect(links.length).toBe(1)
-    expect(links[0].getAttribute('data-snapdom')).toBe('injected-import')
+    expect(links.length).toBe(0)
 
     expect(css).toMatch(/font-family:\s*['"]?Inter['"]?/)
     expect(css).toMatch(/url\(["']?data:/)

--- a/__tests__/module.iconFonts.test.js
+++ b/__tests__/module.iconFonts.test.js
@@ -52,3 +52,39 @@ describe('isIconFont (defaults)', () => {
     expect(isIconFont('Font Awesome 6 Pro')).toBe(true) // match por defaultIconFonts
   })
 })
+
+describe('ligatureIconToImage source pairing (#6)', () => {
+  it('reads styles from the nodeMap-mapped source, not the positional index', async () => {
+    const { ligatureIconToImage } = mod
+    const { cache } = await import('../src/core/cache.js')
+
+    // Source: two material icons with distinct font-sizes.
+    const source = document.createElement('div')
+    const s1 = document.createElement('span')
+    s1.className = 'material-icons'; s1.style.fontFamily = 'Material Icons'; s1.style.fontSize = '99px'; s1.textContent = 'home'
+    const s2 = document.createElement('span')
+    s2.className = 'material-icons'; s2.style.fontFamily = 'Material Icons'; s2.style.fontSize = '24px'; s2.textContent = 'star'
+    source.append(s1, s2)
+    document.body.appendChild(source)
+
+    // Clone: the first icon was dropped (excludeMode:'remove'); only the second survives, so a
+    // positional pairing would wrongly read s1 (99px) for it.
+    const clone = document.createElement('div')
+    const c2 = document.createElement('span')
+    c2.className = 'material-icons'; c2.textContent = 'star'
+    clone.appendChild(c2)
+    document.body.appendChild(clone)
+
+    cache.session.nodeMap = new Map([[c2, s2]])
+
+    await ligatureIconToImage(clone, source)
+
+    const img = c2.querySelector('img')
+    expect(img).toBeTruthy()
+    // Height derives from the mapped source's font-size (24), not index-0's (99).
+    expect(img.style.height).toBe('24px')
+
+    source.remove()
+    clone.remove()
+  })
+})

--- a/__tests__/module.pseudo.test.js
+++ b/__tests__/module.pseudo.test.js
@@ -369,4 +369,36 @@ describe('inlinePseudoElements', () => {
     expect(before).toBeTruthy()
     expect(before.textContent).toBe('1)')
   })
+
+  // #19: a pseudo's own counter-set must override the counter value before resolving content.
+  it('applies counter-set on a pseudo element', async () => {
+    const ol = document.createElement('ol')
+    ol.className = 'cset-ol'
+    const li = document.createElement('li')
+    li.className = 'cset-li'
+    li.textContent = 'x'
+    ol.appendChild(li)
+    document.body.appendChild(ol)
+
+    const style = document.createElement('style')
+    style.textContent = `
+      .cset-ol { counter-reset: item; list-style: none; }
+      .cset-li::before {
+        counter-set: item 41;
+        content: counter(item);
+      }
+    `
+    document.head.appendChild(style)
+
+    const cloneOl = ol.cloneNode(true)
+    const cloneLi = cloneOl.firstElementChild
+    await inlinePseudoElements(li, cloneLi, sessionCache, {})
+
+    const before = cloneLi.querySelector('[data-snapdom-pseudo="::before"]')
+    expect(before).toBeTruthy()
+    expect(before.textContent).toBe('41')
+
+    ol.remove()
+    style.remove()
+  })
 })

--- a/__tests__/module.styles.test.js
+++ b/__tests__/module.styles.test.js
@@ -169,6 +169,32 @@ describe('inlineAllStyles – branches y firmas', () => {
     expect(key).not.toMatch(/font-size:/)
   })
 
+  it('#348: snapshot cache invalidates when excludeStyleProps changes between captures', async () => {
+    const inlineAllStyles = await loadInlineAllStylesFresh()
+
+    const src = document.createElement('div')
+    src.style.color = 'red'
+    src.style.fontSize = '13.37px'
+    document.body.appendChild(src)
+
+    // First capture excludes `color`.
+    const clone1 = document.createElement('div')
+    const session1 = freshSession()
+    await inlineAllStyles(src, clone1, session1, { cache: 'auto', excludeStyleProps: /^color$/ })
+    expect(session1.styleMap.get(clone1)).not.toMatch(/(?:^|;)color:/)
+
+    // Second capture of the SAME element without exclusion. MutationObserver is stubbed so
+    // __epoch is frozen → the per-element snapshot cache would be hit. It must not reuse the
+    // stale snapshot that dropped `color`.
+    const clone2 = document.createElement('div')
+    const session2 = freshSession()
+    await inlineAllStyles(src, clone2, session2, { cache: 'auto' })
+    const key2 = session2.styleMap.get(clone2)
+
+    document.body.removeChild(src)
+    expect(key2).toMatch(/(?:^|;)color:/)
+  })
+
   it('#362: border: 0 solid normalizes to border: none in snapshot', async () => {
     const inlineAllStyles = await loadInlineAllStylesFresh()
 

--- a/__tests__/snapdom.backgroundColor.test.js
+++ b/__tests__/snapdom.backgroundColor.test.js
@@ -40,3 +40,47 @@ describe('snapdom.toJpg backgroundColor option', () => {
     expect(pixel[2]).toBeLessThan(30)    // blue
   })
 })
+
+describe('lossy format flattening at export time (no format on capture)', () => {
+  let container
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.style.width = '100px'
+    container.style.height = '100px'
+    container.style.background = 'transparent'
+    document.body.appendChild(container)
+  })
+
+  // The capture has no `format` (defaults to png, backgroundColor null). The lossy
+  // format is requested only at export time via the result helper. White must still
+  // be flattened in, otherwise JPEG encodes the transparent area as black.
+  it('result.toBlob({ type: "jpeg" }) flattens white instead of black', async () => {
+    const result = await snapdom(container)
+    const blob = await result.toBlob({ type: 'jpeg' })
+    expect(blob.type).toBe('image/jpeg')
+    const img = new Image()
+    img.src = URL.createObjectURL(blob)
+    await img.decode()
+    const canvas = document.createElement('canvas')
+    canvas.width = img.naturalWidth
+    canvas.height = img.naturalHeight
+    const ctx = canvas.getContext('2d')
+    ctx.drawImage(img, 0, 0)
+    const pixel = ctx.getImageData(0, 0, 1, 1).data
+    expect(pixel[0]).toBeGreaterThan(240)
+    expect(pixel[1]).toBeGreaterThan(240)
+    expect(pixel[2]).toBeGreaterThan(240)
+  })
+
+  it('result.toCanvas({ format: "jpeg" }) flattens white instead of leaving transparent', async () => {
+    const result = await snapdom(container)
+    const canvas = await result.toCanvas({ format: 'jpeg' })
+    const ctx = canvas.getContext('2d')
+    const pixel = ctx.getImageData(0, 0, 1, 1).data
+    expect(pixel[3]).toBe(255)            // opaque
+    expect(pixel[0]).toBeGreaterThan(240) // white
+    expect(pixel[1]).toBeGreaterThan(240)
+    expect(pixel[2]).toBeGreaterThan(240)
+  })
+})

--- a/__tests__/utils.image.test.js
+++ b/__tests__/utils.image.test.js
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { inlineSingleBackgroundEntry } from '../src/utils/image.js'
 import { snapFetch } from '../src/modules/snapFetch.js'
+import { safeEncodeURI, resolveURL } from '../src/utils/helpers.js'
 import { cache } from '../src/core/cache.js'
 
 // Silence our intentional rejections so Vitest doesn't flag them as unhandled
@@ -66,9 +67,32 @@ describe('inlineSingleBackgroundEntry', () => {
   it('returns cached data URL when present in cache.background', async () => {
     const url = 'https://example.com/img.png'
     const data = 'data:image/png;base64,AAA'
-    cache.background.set(url, data)
+    // Cache key is `<proxy>|<url>` (no proxy here → empty prefix).
+    cache.background.set(`|${url}`, data)
     const out = await inlineSingleBackgroundEntry(`url("${url}")`)
     expect(out).toBe(`url("${data}")`)
+  })
+
+  it('a no-proxy failure does not poison a later capture using a proxy (#8)', async () => {
+    const url = 'https://cors.example.com/img.png'
+    const encoded = safeEncodeURI(resolveURL(url))
+
+    // No-proxy attempt previously failed → null remembered under the no-proxy key.
+    cache.background.set(`|${encoded}`, null)
+
+    // The no-proxy path still short-circuits to 'none' from its own cached failure.
+    expect(await inlineSingleBackgroundEntry(`url("${url}")`)).toBe('none')
+
+    // A capture WITH a working proxy uses a distinct key, so it fetches fresh instead of
+    // inheriting the poisoned null — the recoverable image is not silently dropped.
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob([new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])], { type: 'image/png' }),
+    }))
+    const out = await inlineSingleBackgroundEntry(`url("${url}")`, { useProxy: 'https://proxy/?u=' })
+    expect(out).not.toBe('none')
+    expect(out).toMatch(/^url\("data:image\/png/)
   })
 
   it('inlines via snapFetch on success (raster path → Image onload)', async () => {

--- a/__tests__/utils.transforms.helpers.test.js
+++ b/__tests__/utils.transforms.helpers.test.js
@@ -40,6 +40,27 @@ describe('parseBoxShadow', () => {
     expect(res.top).toBeGreaterThanOrEqual(0)
     expect(res.right).toBeGreaterThanOrEqual(0)
   })
+
+  it('ignores inset shadows (no outer bleed)', () => {
+    const div = document.createElement('div')
+    div.style.boxShadow = 'inset 10px 10px 5px 2px rgba(0,0,0,0.5)'
+    document.body.appendChild(div)
+    const res = parseBoxShadow(getComputedStyle(div))
+    expect(res).toEqual({ top: 0, right: 0, bottom: 0, left: 0 })
+  })
+
+  it('counts only the outer layer when mixed with an inset layer', () => {
+    const div = document.createElement('div')
+    div.style.boxShadow = 'inset 0 0 40px red, 6px 6px 0 0 blue'
+    document.body.appendChild(div)
+    const res = parseBoxShadow(getComputedStyle(div))
+    // The inset 40px blur must not leak into the bleed (the bug counted it everywhere);
+    // only the 6px outer layer contributes — right/bottom = |6|+6 = 12, all sides << 40.
+    expect(res.right).toBe(12)
+    expect(res.bottom).toBe(12)
+    expect(res.top).toBeLessThanOrEqual(12)
+    expect(res.left).toBeLessThanOrEqual(12)
+  })
 })
 
 describe('parseFilterBlur', () => {
@@ -56,7 +77,16 @@ describe('parseFilterBlur', () => {
     document.body.appendChild(div)
     const cs = getComputedStyle(div)
     const res = parseFilterBlur(cs)
+    // Also guards against double-counting when the engine mirrors filter into webkitFilter.
     expect(res.top).toBe(5)
+  })
+
+  it('sums multiple blur() in the chain (combined spread)', () => {
+    const div = document.createElement('div')
+    div.style.filter = 'blur(2px) blur(3px)'
+    document.body.appendChild(div)
+    const res = parseFilterBlur(getComputedStyle(div))
+    expect(res).toEqual({ top: 5, right: 5, bottom: 5, left: 5 })
   })
 })
 
@@ -222,5 +252,17 @@ describe('normalizeRootTransforms', () => {
     const res = normalizeRootTransforms(orig, clone)
     expect(res).not.toBeNull()
     expect(res.a).toBe(2)
+  })
+
+  it('captures the individual `scale` property when transform is none', () => {
+    const orig = document.createElement('div')
+    orig.style.scale = '2'           // individual property, NOT transform
+    const clone = document.createElement('div')
+    document.body.appendChild(orig)
+    const res = normalizeRootTransforms(orig, clone)
+    // The viewBox must expand by the scale, otherwise the scaled clone gets clipped.
+    expect(res).not.toBeNull()
+    expect(res.a).toBeCloseTo(2, 5)
+    expect(res.d).toBeCloseTo(2, 5)
   })
 })

--- a/src/api/snapdom.js
+++ b/src/api/snapdom.js
@@ -157,10 +157,18 @@ snapdom.capture = async (el, context, _token) => {
     exportsMap.jpg = (ctx, opts) => exportsMap.jpeg(ctx, opts)
   }
 
-  // —— Normalizador para opciones por tipo (p.ej. JPEG: fondo blanco) ——
+  // —— Normalizador para opciones por tipo (p.ej. JPEG/WebP: fondo blanco) ——
   function normalizeExportOptions(type, opts) {
     const next = { ...context, ...(opts || {}) }
-    if (type === 'jpeg' || type === 'jpg') {
+    // `type` aquí es el NOMBRE del export ('blob'/'canvas'/'download'/'jpeg'/…), no el formato
+    // de imagen: en toBlob/toCanvas/download el formato viaja en opts.format/opts.type. Resolver
+    // el formato real (jpg→jpeg) para aplanar el fondo igual que createContext (context.js:84),
+    // o JPEG codificaría las zonas transparentes en negro.
+    const lossy = (s) => s === 'jpeg' || s === 'jpg' || s === 'webp'
+    const fmt = [type, next.format, next.type]
+      .map(v => (typeof v === 'string' ? v.toLowerCase() : ''))
+      .find(lossy)
+    if (fmt) {
       const noBg = next.backgroundColor == null || next.backgroundColor === 'transparent'
       if (noBg) next.backgroundColor = '#ffffff'
     }

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -35,8 +35,8 @@ export const cache = {
   baseStyle: new EvictingMap(MAX_BASE_STYLE),
   computedStyle: new WeakMap(),
   /** Persistent cache for clone-in-document layout measurements (PERF-3).
-   *  Key: Element. Value: { h, w, cssLen } — cssLen is the total injected CSS length,
-   *  used as a cheap invalidation key when styles change between captures. */
+   *  Key: Element. Value: { cssLen, w0, csh, csw } — cssLen is the total injected CSS
+   *  length, used together with w0 as a cheap invalidation key when styles change. */
   measureHints: new WeakMap(),
   font: new Set(),
   session: {
@@ -96,6 +96,7 @@ export function applyCachePolicy(policy = 'soft') {
       cache.session.styleCache = new WeakMap()
 
       cache.computedStyle = new WeakMap()
+      cache.measureHints  = new WeakMap()
       cache.baseStyle     = new EvictingMap(MAX_BASE_STYLE)
       cache.defaultStyle  = new EvictingMap(MAX_DEFAULT_STYLE)
       cache.image         = new EvictingMap(MAX_IMAGE)

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -25,6 +25,26 @@ import { isFirefox } from '../utils/browser.js'
 
 // helper implementations moved to ../utils/clone.helpers.js
 
+/**
+ * Build a hidden, layout-preserving spacer matching a node's unscaled box, used when a node is
+ * excluded/filtered in 'hide' mode. Forces at most one getBoundingClientRect (the inline form
+ * could read it twice per node in the hot path).
+ * @param {Element} node
+ * @returns {HTMLDivElement}
+ */
+function makeHideSpacer(node) {
+  const { width, height } = getUnscaledDimensions(node)
+  let w = width, h = height
+  if (!w || !h) {
+    const rect = node.getBoundingClientRect()
+    w = w || rect.width || 0
+    h = h || rect.height || 0
+  }
+  const spacer = document.createElement('div')
+  spacer.style.cssText = `display:inline-block;width:${w}px;height:${h}px;visibility:hidden;`
+  return spacer
+}
+
 export async function deepClone(node, sessionCache, options) {
   if (!node) throw new Error('Invalid node')
   const clonedAssignedNodes = new Set()
@@ -55,12 +75,7 @@ export async function deepClone(node, sessionCache, options) {
   }
   if (node.getAttribute('data-capture') === 'exclude') {
     if (options.excludeMode === 'hide') {
-      const spacer = document.createElement('div')
-      const { width, height } = getUnscaledDimensions(node)
-      const w = width || node.getBoundingClientRect().width || 0
-      const h = height || node.getBoundingClientRect().height || 0
-      spacer.style.cssText = `display:inline-block;width:${w}px;height:${h}px;visibility:hidden;`
-      return spacer
+      return makeHideSpacer(node)
     } else if (options.excludeMode === 'remove') {
       return null
     }
@@ -70,12 +85,7 @@ export async function deepClone(node, sessionCache, options) {
       try {
         if (node.matches?.(selector)) {
           if (options.excludeMode === 'hide') {
-            const spacer = document.createElement('div')
-            const { width, height } = getUnscaledDimensions(node)
-            const w = width || node.getBoundingClientRect().width || 0
-            const h = height || node.getBoundingClientRect().height || 0
-            spacer.style.cssText = `display:inline-block;width:${w}px;height:${h}px;visibility:hidden;`
-            return spacer
+            return makeHideSpacer(node)
           } else if (options.excludeMode === 'remove') {
             return null
           }
@@ -89,12 +99,7 @@ export async function deepClone(node, sessionCache, options) {
     try {
       if (!options.filter(node)) {
         if (options.filterMode === 'hide') {
-          const spacer = document.createElement('div')
-          const { width, height } = getUnscaledDimensions(node)
-          const w = width || node.getBoundingClientRect().width || 0
-          const h = height || node.getBoundingClientRect().height || 0
-          spacer.style.cssText = `display:inline-block;width:${w}px;height:${h}px;visibility:hidden;`
-          return spacer
+          return makeHideSpacer(node)
         } else if (options.filterMode === 'remove') {
           return null
         }

--- a/src/core/plugins.js
+++ b/src/core/plugins.js
@@ -63,8 +63,7 @@ export function registerPlugins(...defs) {
  * @returns {readonly any[]}
  */
 function getContextPlugins(context) {
-  const arr = context && Array.isArray(context.plugins) ? context.plugins : __plugins
-  return arr || __plugins
+  return context && Array.isArray(context.plugins) ? context.plugins : __plugins
 }
 
 /**
@@ -105,12 +104,6 @@ export async function runAll(name, context, payload) {
   }
   return outs
 }
-
-/**
- * Return a shallow copy of currently registered global plugins.
- * @returns {any[]}
- */
-export function pluginsList() { return __plugins.slice() }
 
 /** Clear all globally registered plugins (mostly for tests). */
 export function clearPlugins() { __plugins.length = 0 }

--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -41,18 +41,22 @@ export async function prepareClone(element, options = {}) {
   const undoContentVisibility = forceContentVisibility(element)
 
   try {
-    inlineExternalDefsAndSymbols(element)
-  } catch (e) {
-    console.warn('inlineExternal defs or symbol failed:', e)
-  }
-
-  try {
     clone = await deepClone(element, sessionCache, options)
   } catch (e) {
     console.warn('deepClone failed:', e)
     throw e
   } finally {
     undoContentVisibility()
+  }
+
+  // Inline external <defs>/<symbol> into the CLONE, not the live source. Operating on the
+  // source mutated the user's DOM (a hidden <svg> was inserted as firstChild and never
+  // removed) and shifted :first-child/nth-child matches while deepClone read computed
+  // styles. The clone is detached; external refs are still resolved from the live document.
+  try {
+    inlineExternalDefsAndSymbols(clone)
+  } catch (e) {
+    console.warn('inlineExternal defs or symbol failed:', e)
   }
   try {
     await inlinePseudoElements(element, clone, sessionCache, options)

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -103,10 +103,22 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
       const bis = style.getPropertyValue('border-image-source')
       return (bi && bi !== 'none') || (bis && bis !== 'none')
     })()
-    for (const prop of BG_LAYOUT_PROPS) {
-      const v = style.getPropertyValue(prop)
-      if (!v) continue
-      cloneNode.style.setProperty(prop, v)
+    // Background layout longhands (position/size/repeat/origin/clip/...) are inert without a
+    // background, yet are never empty, so copying them onto every node bloated the markup and
+    // rasterization cost. Copy only when a background actually exists. background-color is
+    // included so the background-clip:text trick (color clipped to text) still works.
+    const bgImage = style.getPropertyValue('background-image')
+    const bgColor = style.getPropertyValue('background-color')
+    const hasBg =
+      (bgImage && bgImage !== 'none') ||
+      (bgColor && bgColor !== 'rgba(0, 0, 0, 0)' && bgColor !== 'transparent') ||
+      /url\s*\(|gradient\s*\(/i.test(style.getPropertyValue('background') || '')
+    if (hasBg) {
+      for (const prop of BG_LAYOUT_PROPS) {
+        const v = style.getPropertyValue(prop)
+        if (!v) continue
+        cloneNode.style.setProperty(prop, v)
+      }
     }
     // 1) Inline URL-bearing properties
     for (const prop of URL_PROPS) {

--- a/src/modules/counter.js
+++ b/src/modules/counter.js
@@ -15,11 +15,6 @@ export function hasCounters(input) {
   return /\bcounter\s*\(|\bcounters\s*\(/.test(input || '')
 }
 
-/** Replace every CSS string token "..." with its raw content (keeps single quotes). */
-export function unquoteDoubleStrings(s) {
-  return (s || '').replace(/"([^"]*)"/g, '$1')
-}
-
 /**
  * a, b, ..., z, aa, ab, ...
  * @param {number} n
@@ -255,9 +250,8 @@ export function buildCounterContext(root) {
 /**
  * Resolves counter()/counters() calls inside a content string for a specific node,
  * returning the content with counter() expanded but quoted-string tokens preserved.
- * The caller is responsible for joining tokens (see pseudo.js collapseCssContent)
- * or stripping quotes (see resolvePseudoContent below) — keeping quotes here lets
- * collapseCssContent tokenize properly so source whitespace between adjacent
+ * The caller (pseudo.js) is responsible for joining tokens and stripping quotes —
+ * keeping quotes here lets its tokenizer work so source whitespace between adjacent
  * tokens (e.g. `counter(x) ")"`) doesn't leak into the rendered text.
  *
  * @param {string} raw
@@ -288,102 +282,4 @@ export function resolveCountersInContent(raw, node, ctx) {
   } catch {
     return '- '
   }
-}
-
-/**
- * Create a derived counter context that applies a pseudo's counter-reset /
- * counter-increment *for this node only*, before resolving content.
- * Works with ::before / ::after (and any pseudo with content).
- *
- * @param {Element} node
- * @param {CSSStyleDeclaration|null} pseudoStyle getComputedStyle(node, '::before' | '::after')
- * @param {{get(node: Element, name: string): number, getStack(node: Element, name: string): number[]}} baseCtx
- */
-export function deriveCounterCtxForPseudo(node, pseudoStyle, baseCtx) {
-  const modStacks = new Map()
-
-  /** Parse "a 1, b -2" -> [{name:'a', num:1}, {name:'b', num:-2}] */
-  function parseListDecl(value) {
-    const out = []
-    if (!value || value === 'none') return out
-    for (const part of String(value).split(',')) {
-      const toks = part.trim().split(/\s+/)
-      const name = toks[0]
-      const num = Number.isFinite(Number(toks[1])) ? Number(toks[1]) : undefined
-      if (name) out.push({ name, num })
-    }
-    return out
-  }
-
-  const resets = parseListDecl(pseudoStyle?.counterReset)
-  const sets   = parseListDecl(pseudoStyle?.counterSet)
-  const incs   = parseListDecl(pseudoStyle?.counterIncrement)
-
-  function getStackDerived(name) {
-    if (modStacks.has(name)) return modStacks.get(name).slice()
-
-    // base stack at this node from the element context
-    let stack = baseCtx.getStack(node, name)
-    stack = stack.length ? stack.slice() : []
-
-    // counter-reset (push if exists, replace if not)
-    const r = resets.find(x => x.name === name)
-    if (r) {
-      const val = Number.isFinite(r.num) ? r.num : 0
-      if (stack.length) {
-        stack = stack.slice()
-        stack.push(val)
-      } else {
-        stack = [val]
-      }
-    }
-
-    // counter-set (set top value without creating a new scope)
-    const s = sets.find(x => x.name === name)
-    if (s) {
-      const val = Number.isFinite(s.num) ? s.num : 0
-      if (stack.length === 0) stack = [0]
-      stack[stack.length - 1] = val
-    }
-
-    // counter-increment (on top; create top=0 if missing)
-    const inc = incs.find(x => x.name === name)
-    if (inc) {
-      const by = Number.isFinite(inc.num) ? inc.num : 1
-      if (stack.length === 0) stack = [0]
-      stack[stack.length - 1] += by
-    }
-
-    modStacks.set(name, stack.slice())
-    return stack
-  }
-
-  return {
-    get(_node, name) {
-      const s = getStackDerived(name)
-      return s.length ? s[s.length - 1] : 0
-    },
-    getStack(_node, name) {
-      return getStackDerived(name)
-    }
-  }
-}
-
-/**
- * Convenience helper: resolve the final text to render for a pseudo's `content`,
- * correctly applying the pseudo's own counter-reset/increment before evaluation.
- *
- * @param {Element} node
- * @param {'::before'|'::after'} pseudo
- * @param {{get(node: Element, name: string): number, getStack(node: Element, name: string): number[]}} baseCtx
- * @returns {string} resolved content (without surrounding double quotes)
- */
-export function resolvePseudoContent(node, pseudo, baseCtx) {
-  let ps
-  try { ps = getComputedStyle(node, pseudo) } catch {}
-  const raw = ps?.content
-  if (!raw || raw === 'none' || raw === 'normal') return ''
-  const derived = deriveCounterCtxForPseudo(node, ps, baseCtx)
-  let out = resolveCountersInContent(raw, node, derived)
-  return unquoteDoubleStrings(out)
 }

--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -627,14 +627,17 @@ export async function embedCustomFonts({
   if (!(required instanceof Set)) required = new Set()
   if (!(usedCodepoints instanceof Set)) usedCodepoints = new Set()
 
-  // Build index: family -> [{w,s,st}]
+  // Build index: family -> [{w,s,st}]. CSS font-family names are case-insensitive, so the
+  // index is keyed lowercase and every lookup lowercases too — otherwise a page using
+  // `Roboto` against `@font-face { font-family: roboto }` would silently fail to embed.
   const requiredIndex = new Map()
   for (const key of required) {
     const [fam, w, s, st] = String(key).split('__')
     if (!fam) continue
-    const arr = requiredIndex.get(fam) || []
+    const famKey = fam.toLowerCase()
+    const arr = requiredIndex.get(famKey) || []
     arr.push({ w: parseInt(w, 10), s, st: parseInt(st, 10) })
-    requiredIndex.set(fam, arr)
+    requiredIndex.set(famKey, arr)
   }
 
   /**
@@ -655,9 +658,10 @@ export async function embedCustomFonts({
  * @param {string} stretchSpec font-stretch desde @font-face (p.ej. "100%")
  */
 function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
-  if (!requiredIndex.has(fam)) return false
+  const famKey = String(fam).toLowerCase()
+  if (!requiredIndex.has(famKey)) return false
 
-  const need = requiredIndex.get(fam)
+  const need = requiredIndex.get(famKey)
   const ws = parseWeightSpec(weightSpec)
   const ss = parseStyleSpec(styleSpec)
   const ts = parseStretchSpec(stretchSpec)
@@ -860,7 +864,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
       if (!f || !f.family || f.status !== 'loaded' || !f._snapdomSrc) continue
       const fam = String(f.family).replace(/^['"]+|['"]+$/g, '')
       if (isIconFont(fam)) continue
-      if (!requiredIndex.has(fam)) continue
+      if (!requiredIndex.has(fam.toLowerCase())) continue
 
       if (exclude?.families && exclude.families.some(n => String(n).toLowerCase() === fam.toLowerCase())) {
         continue
@@ -896,7 +900,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
     if (!font || typeof font !== 'object') continue
     const family = String(font.family || '').replace(/^['"]+|['"]+$/g, '')
     if (!family || isIconFont(family)) continue
-    if (!requiredIndex.has(family)) continue
+    if (!requiredIndex.has(family.toLowerCase())) continue
     if (exclude?.families && exclude.families.some(n => String(n).toLowerCase() === family.toLowerCase())) continue
 
     const weight = font.weight != null ? String(font.weight) : 'normal'

--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -736,6 +736,9 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
       if (!hasLink) importUrls.push(u)
     }
   }
+  // @import font URLs with no matching <link> are made reachable by injecting a temporary
+  // <link>. These are tracked and removed below so the capture never mutates the user's DOM.
+  const injectedLinks = []
   if (importUrls.length) {
     await Promise.all(importUrls.map((u) => new Promise((resolve) => {
       if (document.querySelector(`link[rel="stylesheet"][href="${u}"]`)) return resolve(null)
@@ -746,13 +749,17 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
       link.onload = () => resolve(link)
       link.onerror = () => resolve(null)
       document.head.appendChild(link)
+      injectedLinks.push(link)
     })))
   }
 
   let finalCSS = ''
 
   // ---------- 1) External <link rel="stylesheet"> ----------
+  // Snapshot BEFORE detaching the injected links so their @import'd font CSS is still
+  // collected below, then remove them from <head> to keep the capture non-destructive.
   const linkNodes = Array.from(document.querySelectorAll('link[rel="stylesheet"]')).filter(l => !!l.href)
+  for (const l of injectedLinks) { try { l.remove() } catch { /* ok */ } }
 
   for (const link of linkNodes) {
     try {

--- a/src/modules/iconFonts.js
+++ b/src/modules/iconFonts.js
@@ -1,4 +1,5 @@
 // iconFonts.js
+import { cache } from '../core/cache.js'
 
 // ---------------------------------------------------------------------------
 // Detection / configuration (kept as-is + extensible)
@@ -235,6 +236,10 @@ export async function ligatureIconToImage(cloneRoot, sourceRoot) {
 
   if (cloneNodes.length === 0) return 0
 
+  // Map each clone node to its exact source via the clone→source nodeMap built by deepClone.
+  // Pairing the two trees positionally breaks when excludeMode:'remove' drops nodes from the
+  // clone but not the source: indices shift and we read the wrong source's color/size/variation.
+  const nodeMap = cache.session.nodeMap
   const sourceNodes = (sourceRoot instanceof Element)
     ? Array.from(sourceRoot.querySelectorAll(selector)).filter(n => n && n.textContent && n.textContent.trim())
     : []
@@ -243,7 +248,7 @@ export async function ligatureIconToImage(cloneRoot, sourceRoot) {
 
   for (let i = 0; i < cloneNodes.length; i++) {
     const el = cloneNodes[i]
-    const src = sourceNodes[i] || null
+    const src = (nodeMap && nodeMap.get(el)) || sourceNodes[i] || null
 
     try {
       const cs = src ? getComputedStyle(src) : getComputedStyle(el)

--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -39,10 +39,10 @@ const CSS_RULE_SCAN_BUDGET = 1000
  */
 function preflightWithFp(doc, sessionCache) {
   const fp = styleFingerprint(doc)
-  if (!sessionCache) return shouldProcessPseudos(doc)
+  if (!sessionCache) return shouldProcessPseudos(doc, fp)
   // Recompute when the fingerprint changes
   if (sessionCache.__pseudoPreflightFp !== fp) {
-    sessionCache.__pseudoPreflight = shouldProcessPseudos(doc)
+    sessionCache.__pseudoPreflight = shouldProcessPseudos(doc, fp)
     sessionCache.__pseudoPreflightFp = fp
   }
   return !!sessionCache.__pseudoPreflight
@@ -153,8 +153,7 @@ function sheetHasNeedles(sheet, needles, state) {
  * @param {Document} doc
  * @returns {boolean}
  */
-export function shouldProcessPseudos(doc = document) {
-  const fp = styleFingerprint(doc)
+export function shouldProcessPseudos(doc = document, fp = styleFingerprint(doc)) {
   const memo = __preflightMemo.get(doc)
   if (memo && memo.fingerprint === fp) return memo.result
 

--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -299,6 +299,7 @@ function deriveCounterCtxForPseudo(node, pseudoStyle, baseCtx) {
   }
 
   const resets = parseListDecl(pseudoStyle?.counterReset)
+  const sets = parseListDecl(pseudoStyle?.counterSet)
   const incs = parseListDecl(pseudoStyle?.counterIncrement)
 
   function getStackDerived(name) {
@@ -311,6 +312,14 @@ function deriveCounterCtxForPseudo(node, pseudoStyle, baseCtx) {
     if (r) {
       const val = Number.isFinite(r.num) ? r.num : 0
       stack = stack.length ? [...stack, val] : [val]
+    }
+
+    // counter-set: fija el valor del top sin crear scope (orden CSS: reset → set → increment)
+    const s = sets.find(x => x.name === name)
+    if (s) {
+      const val = Number.isFinite(s.num) ? s.num : 0
+      if (stack.length === 0) stack = [0]
+      stack[stack.length - 1] = val
     }
 
     // increment: sobre el top, crear top=0 si no existe

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -149,11 +149,17 @@ function styleSignature(snap) {
 }
 function getSnapshot(el, preStyle = null, options = {}) {
   const rec = snapshotCache.get(el)
-  if (rec && rec.epoch === __epoch) return rec.snapshot
+  // The snapshot content depends on embedFonts (extra font props) and excludeStyleProps
+  // (skipped props), but __epoch only bumps on DOM/font mutation — not option changes.
+  // Capturing the same element twice with different options must not reuse the snapshot
+  // (#348). excludeStyleProps is compared by reference: a fresh value misses safely.
+  const ef = !!(options && options.embedFonts)
+  const ex = (options && options.excludeStyleProps) || null
+  if (rec && rec.epoch === __epoch && rec.embedFonts === ef && rec.excludeStyleProps === ex) return rec.snapshot
   const style = preStyle || getComputedStyle(el)
   const snap = snapshotComputedStyleFull(style, options)
   stripHeightForWrappers(el, style, snap)
-  snapshotCache.set(el, { epoch: __epoch, snapshot: snap })
+  snapshotCache.set(el, { epoch: __epoch, snapshot: snap, embedFonts: ef, excludeStyleProps: ex })
   return snap
 }
 

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -1,4 +1,4 @@
-import { getStyleKey, shouldIgnoreProp } from '../utils/index.js'
+import { getStyleKey, shouldIgnoreProp, getStyle } from '../utils/index.js'
 import { cache } from '../core/cache.js'
 
 const snapshotCache = new WeakMap()
@@ -303,7 +303,9 @@ function hasBox(cs) {
 function isFlexOrGridItem(el) {
   const p = el.parentElement
   if (!p) return false
-  const pd = getComputedStyle(p).display || ''
+  // getStyle memoizes in cache.computedStyle; raw getComputedStyle forced a fresh resolution
+  // per node on every capture (even on snapshot-cache hits).
+  const pd = getStyle(p).display || ''
   return pd.includes('flex') || pd.includes('grid')
 }
 

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -26,11 +26,15 @@ export async function inlineSingleBackgroundEntry(entry, options = {}) {
   }
   // Resolve relative URLs to absolute (fixes #343: background url() missing when relative)
   const absoluteUrl = resolveURL(rawUrl)
-  // Normalize / encode the URL string for cache key & fetch
+  // Normalize / encode the URL string for fetch
   const encodedUrl = safeEncodeURI(absoluteUrl)
+  // Cache key includes the proxy: a CORS failure under one proxy setting must not poison
+  // a later capture of the same URL with a working proxy (a `null` would mask a recoverable
+  // image). Successes are also keyed per proxy, which is constant in practice.
+  const cacheKey = (options.useProxy || '') + '|' + encodedUrl
   // Fast path: cached success
-  if (cache.background.has(encodedUrl)) {
-    const dataUrl = cache.background.get(encodedUrl)
+  if (cache.background.has(cacheKey)) {
+    const dataUrl = cache.background.get(cacheKey)
     return dataUrl ? `url("${dataUrl}")` : 'none'
   }
   // Try to inline; never throw — degrade to "none" on failure
@@ -38,15 +42,15 @@ export async function inlineSingleBackgroundEntry(entry, options = {}) {
     const dataUrl = await snapFetch(encodedUrl, { as: 'dataURL', useProxy: options.useProxy })
     // Guard: ensure it actually looks like an image data URL
     if (dataUrl.ok) {
-      cache.background.set(encodedUrl, dataUrl.data)
+      cache.background.set(cacheKey, dataUrl.data)
       return `url("${dataUrl.data}")`
     }
     // Unexpected format → degrade safely
-    cache.background.set(encodedUrl, null)
+    cache.background.set(cacheKey, null)
     return 'none'
   } catch {
     // On any error (404/CORS/timeout/tainted/etc.), don't break the capture
-    cache.background.set(encodedUrl, null) // remember failure to avoid loops
+    cache.background.set(cacheKey, null) // remember failure to avoid loops
     return 'none'
   }
 }

--- a/src/utils/transforms.helpers.js
+++ b/src/utils/transforms.helpers.js
@@ -13,9 +13,22 @@ import { limitDecimals } from './capture.helpers.js'
 export function parseBoxShadow(cs) {
   const v = cs.boxShadow || ''
   if (!v || v === 'none') return { top: 0, right: 0, bottom: 0, left: 0 }
-  const parts = v.split(/\),(?=(?:[^()]*\([^()]*\))*[^()]*$)/).map((s) => s.trim())
+  // Split into layers on top-level commas only (commas inside rgb()/rgba() must not split).
+  // A regex on `),` fails for computed values, which put the color first (color()-last is
+  // author syntax) — so a multi-layer shadow would not be separated.
+  const parts = []
+  let buf = '', depth = 0
+  for (let i = 0; i < v.length; i++) {
+    const ch = v[i]
+    if (ch === '(') depth++
+    else if (ch === ')') depth = Math.max(0, depth - 1)
+    if (ch === ',' && depth === 0) { parts.push(buf); buf = '' } else buf += ch
+  }
+  if (buf.trim()) parts.push(buf)
   let t = 0, r = 0, b2 = 0, l = 0
   for (const part of parts) {
+    // inset shadows are clipped to the padding box and contribute no outer bleed.
+    if (/\binset\b/i.test(part)) continue
     const nums = part.match(/-?\d+(\.\d+)?px/g)?.map((n) => parseFloat(n)) || []
     if (nums.length < 2) continue
     const [ox2, oy2, blur = 0, spread = 0] = nums
@@ -35,8 +48,15 @@ export function parseBoxShadow(cs) {
  * @returns {{top: number, right: number, bottom: number, left: number}}
  */
 export function parseFilterBlur(cs) {
-  const m = (cs.filter || '').match(/blur\(\s*([0-9.]+)px\s*\)/)
-  const b2 = m ? Math.ceil(parseFloat(m[1]) || 0) : 0
+  // Read the standard `filter`, falling back to `-webkit-filter` when filter is unset, so
+  // WebKit-only blurs still expand the bleed. Use the standard one alone when present to
+  // avoid double-counting (browsers often mirror filter into webkitFilter). Sum every
+  // blur() in the chosen list to cover the rare multi-blur case.
+  const raw = (cs.filter && cs.filter !== 'none') ? cs.filter : (cs.webkitFilter || '')
+  const re = /blur\(\s*([0-9.]+)px\s*\)/gi
+  let total = 0, m
+  while ((m = re.exec(raw))) total += parseFloat(m[1]) || 0
+  const b2 = Math.ceil(total)
   return { top: b2, right: b2, bottom: b2, left: b2 }
 }
 
@@ -115,15 +135,21 @@ export function normalizeRootTransforms(originalEl, cloneRoot) {
 
   const tr = cs.transform || 'none'
   if (!tr || tr === 'none') {
-    // May still have individual scale; let computed matrix capture it
-    try {
-      const M = matrixFromComputed(originalEl)
-      // If identity, nothing to apply
-      if ((M.a === 1 && M.b === 0 && M.c === 0 && M.d === 1)) {
-        cloneRoot.style.transform = 'none'
-        return { a: 1, b: 0, c: 0, d: 1 }
-      }
-    } catch { }
+    // No `transform`, but the element may still use the individual `scale` property, which
+    // composes separately from `transform` (matrixFromComputed only reads `transform`, so it
+    // would miss it and leave the viewBox unscaled, clipping the content). translate/rotate
+    // were already stripped from the clone above and the clone keeps `scale`, so report the
+    // scale matrix for bbox expansion — do NOT write it to transform or scale applies twice.
+    let scaleStr = null
+    try { scaleStr = readIndividualTransforms(originalEl).scale } catch { }
+    try { cloneRoot.style.transform = 'none' } catch { }
+    if (!scaleStr) return { a: 1, b: 0, c: 0, d: 1 }
+    // `scale` is unitless: "sx" or "sx sy". Parse straight to a diagonal matrix — it does not
+    // surface in computed `transform`, so a temp-element round-trip would read back identity.
+    const sv = scaleStr.trim().split(/\s+/).map(parseFloat)
+    const sx = Number.isFinite(sv[0]) ? sv[0] : 1
+    const sy = Number.isFinite(sv[1]) ? sv[1] : sx
+    return { a: sx, b: 0, c: 0, d: sy }
   }
 
   // Helper: decompose 2D matrix components (a,b,c,d) into scale+shear without rotation

--- a/src/utils/transforms.helpers.js
+++ b/src/utils/transforms.helpers.js
@@ -4,6 +4,7 @@
  */
 
 import { limitDecimals } from './capture.helpers.js'
+import { getStyle } from './css.js'
 
 /**
  * Parse box-shadow and calculate bleed dimensions
@@ -396,7 +397,9 @@ export function readTotalTransformMatrix(t) {
  * @param {Element} el
  */
 export function hasBBoxAffectingTransform(el) {
-  const cs = getComputedStyle(el)
+  // getStyle is cached (cache.computedStyle); on the root this reuses the csEl already read by
+  // captureDOM instead of forcing a fresh resolution per call (twice on Safari defaults).
+  const cs = getStyle(el)
   const t = cs.transform || 'none'
 
   // Matrix identity or none => might still have individual transforms


### PR DESCRIPTION
Batch of fixes from an exhaustive multi-agent review of `src/`, each adversarially verified against the real code and covered by tests. The full suite (774 tests incl. snapDiff visual demos) is green. Each fix is its own commit.

## 🔴 Critical
- **JPEG/WebP background flattened by resolved format, not export name** (`src/api/snapdom.js`). `result.toBlob({type:'jpeg'})` / `toCanvas({format:'jpeg'})` / `download({format:'jpeg'})` on a no-format capture left `backgroundColor` null, so JPEG encoded transparent areas as **black**. `normalizeExportOptions` now resolves the real lossy format and flattens white, matching `createContext`.

## Fidelity / correctness
- **Non-destructive capture** (`prepare.js`, `svgDefs.js`, `fonts.js`): the capture no longer mutates the live DOM. External SVG `<defs>`/`<symbol>` inlining now runs on the detached clone (it used to insert a hidden `<svg>` as the source's firstChild and never remove it — also perturbing `:first-child`/`nth-child` while styles were read). `@import` font `<link>`s injected into `<head>` are now removed after use.
- **bbox/bleed math** (`transforms.helpers.js`): inset box-shadows no longer inflate outer bleed (+ layer splitter rewritten for multi-layer computed values); `parseFilterBlur` reads `-webkit-filter` and sums blur chains; `normalizeRootTransforms` honors the individual `scale` property when `transform` is none (was clipping scaled roots).
- **Caches** (`cache.js`, `styles.js`): snapshot cache is invalidated when `embedFonts`/`excludeStyleProps` change between captures (was silently reusing stale snapshots, breaking #348 on repeat captures); `cache:'disabled'` now also resets `measureHints`.
- **Misc correctness**: `cache.background` keyed by proxy (a no-proxy CORS failure no longer poisons a later proxied capture); case-insensitive `@font-face` family matching; material-icon clone↔source pairing via the deepClone nodeMap instead of fragile index pairing (broke under `excludeMode:'remove'`).
- **counter-set**: the live pseudo path now applies `counter-set` (CSS order reset → set → increment).

## Performance (hot path, behavior-preserving)
- Background layout longhands copied only when a background exists (were written to every clone node).
- `isFlexOrGridItem` and `hasBBoxAffectingTransform` use the cached `getStyle` instead of raw `getComputedStyle`.
- `shouldProcessPseudos` reuses the already-computed style fingerprint.
- The three identical exclude/filter "hide spacer" blocks are one helper reading layout at most once.

## Dead code
- Removed the divergent, never-imported `deriveCounterCtxForPseudo`/`resolvePseudoContent`/`unquoteDoubleStrings` duplicates in `counter.js` (the divergence is exactly what let the counter-set bug hide behind passing tests), the unused `pluginsList`, and an unreachable `|| __plugins` fallback.

### Notes
- Did **not** touch the Safari warmup (`safariWarmupAttempts`) finding — it lives in a WebKit-only path the test env (headless Chromium) can't validate, per the repo's fidelity guidance.
- Investigated open issue **#421** (vertical drift on repeated canvas exports): the cache-correctness fixes here are plausibly related but I could not reproduce/confirm it, so I'm not claiming it closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)