### PR TITLE
fix: use nodeMap for source/clone child alignment in inlineBackgroundImages

### DIFF
--- a/__tests__/module.background.test.js
+++ b/__tests__/module.background.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { inlineBackgroundImages } from '../src/modules/background.js'
+import { cache } from '../src/core/cache.js'
 
 describe('inlineBackgroundImages', () => {
   let source, clone
@@ -22,5 +23,86 @@ describe('inlineBackgroundImages', () => {
   it('processes a valid background-image', async () => {
     source.style.backgroundImage = 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAn8B9p6Q2wAAAABJRU5ErkJggg==")'
     await expect(inlineBackgroundImages(source, clone, new WeakMap())).resolves.toBeUndefined()
+  })
+
+  describe('child alignment with clone-only elements (#439)', () => {
+    const attached = []
+
+    /** Create a div, optionally with background, and append to parent */
+    function div(parent, bg) {
+      const el = document.createElement('div')
+      if (bg) el.style.backgroundImage = bg
+      if (parent) parent.appendChild(el)
+      return el
+    }
+
+    /** Mount an element to the document for computed style resolution */
+    function mount(el) {
+      document.body.appendChild(el)
+      attached.push(el)
+      return el
+    }
+
+    /** Register clone→source in nodeMap */
+    function link(cloneEl, srcEl) {
+      cache.session.nodeMap.set(cloneEl, srcEl)
+    }
+
+    beforeEach(() => { cache.session.nodeMap = new Map() })
+    afterEach(() => { attached.forEach(el => el.remove()) })
+
+    it('skips injected SVG and applies gradient to correct clone child', async () => {
+      const src = mount(document.createElement('div'))
+      const srcHeader = div(src)
+      const srcBody = div(src, 'linear-gradient(red, blue)')
+
+      const cln = mount(document.createElement('div'))
+      const injected = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      cln.appendChild(injected) // no nodeMap entry — clone-only
+      const clnHeader = div(cln)
+      const clnBody = div(cln)
+
+      link(cln, src); link(clnHeader, srcHeader); link(clnBody, srcBody)
+      await inlineBackgroundImages(src, cln, new WeakMap())
+
+      expect(clnHeader.style.backgroundImage).not.toContain('linear-gradient')
+      expect(clnBody.style.backgroundImage).toContain('linear-gradient')
+    })
+
+    it('pairs correctly without injected elements', async () => {
+      const src = mount(document.createElement('div'))
+      const src1 = div(src, 'linear-gradient(green, yellow)')
+      const src2 = div(src, 'linear-gradient(purple, orange)')
+
+      const cln = mount(document.createElement('div'))
+      const cln1 = div(cln)
+      const cln2 = div(cln)
+
+      link(cln, src); link(cln1, src1); link(cln2, src2)
+      await inlineBackgroundImages(src, cln, new WeakMap())
+
+      expect(cln1.style.backgroundImage).toContain('green')
+      expect(cln2.style.backgroundImage).toContain('purple')
+    })
+
+    it('skips multiple injected elements at various positions', async () => {
+      const src = mount(document.createElement('div'))
+      const srcA = div(src, 'linear-gradient(red, blue)')
+      const srcB = div(src)
+
+      const cln = mount(document.createElement('div'))
+      cln.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'svg')) // injected
+      const clnA = div(cln)
+      const pseudo = document.createElement('span')
+      pseudo.dataset.snapdomPseudo = '::after'
+      cln.appendChild(pseudo) // injected
+      const clnB = div(cln)
+
+      link(cln, src); link(clnA, srcA); link(clnB, srcB)
+      await inlineBackgroundImages(src, cln, new WeakMap())
+
+      expect(clnA.style.backgroundImage).toContain('linear-gradient')
+      expect(clnB.style.backgroundImage || '').not.toContain('linear-gradient')
+    })
   })
 })

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -4,6 +4,7 @@
  */
 
 import { getStyle, inlineSingleBackgroundEntry, splitBackgroundImage } from '../utils'
+import { cache } from '../core/cache.js'
 
 /**
  * Recursively inlines background-related images and masks from the source element to its clone.
@@ -159,23 +160,23 @@ export async function inlineBackgroundImages(source, clone, styleCache, options 
         cloneNode.style.setProperty(prop, val)
       }
     }
-    // 4) Recurse
-    // Fix: When srcNode is a shadow DOM host, its light DOM children are empty
-    // (content lives in shadowRoot). Use shadowRoot.children instead, filtering
-    // out <style> elements which are skipped during shadow DOM cloning.
-    const sChildren = srcNode.shadowRoot
-      ? Array.from(srcNode.shadowRoot.children).filter(el => el.tagName !== 'STYLE')
-      : Array.from(srcNode.children)
-    const cChildren = Array.from(cloneNode.children)
-      .filter(el => {
-        if (el.dataset?.snapdomPseudo) return false
-        // Only exclude injected <style data-sd> tags, not shadow DOM host elements
-        if (el.tagName === 'STYLE' && el.dataset?.sd) return false
-        return true
-      })
-
-    for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
-      queue.push([sChildren[i], cChildren[i]])
+    // 4) Recurse — use nodeMap (clone→source) for child alignment instead of
+    //    index-based pairing, which breaks when clone-only elements (e.g.
+    //    svg.inline-defs-container) shift indices (#439).
+    if (srcNode.shadowRoot) {
+      const sChildren = Array.from(srcNode.shadowRoot.children).filter(el => el.tagName !== 'STYLE')
+      const cChildren = Array.from(cloneNode.children)
+        .filter(el => !el.dataset?.snapdomPseudo && !(el.tagName === 'STYLE' && el.dataset?.sd))
+      for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
+        queue.push([sChildren[i], cChildren[i]])
+      }
+    } else {
+      const nodeMap = cache.session.nodeMap
+      for (const cChild of cloneNode.children) {
+        const srcChild = nodeMap.get(cChild)
+        if (!srcChild) continue
+        queue.push([srcChild, cChild])
+      }
     }
   }
 }


### PR DESCRIPTION
## Fix

Replaces fragile index-based child pairing with `nodeMap` lookup (clone → source) in the recursion step of `inlineBackgroundImages`.

Fixes #439

### Live Demos

**Bug:** https://jsfiddle.net/0gbnzsr1/3/ — body gradient bleeds into the header
**Fix:** https://jsfiddle.net/y5jvgphc/ — same setup using the patched build, no bleed

### Problem

`inlineBackgroundImages` walks source and clone children in parallel by index, assuming they are 1:1 aligned. `inlineExternalDefsAndSymbols` inserts an `svg.inline-defs-container` as the first child of the clone — an element that does not exist in the source. This shifts all subsequent indices by one, causing background properties from source element N to be applied to clone element N-1.

```
Source children:  [Header(0),  Body(1),         Footer(2)]
Clone children:   [svg.defs(0), Header(1),       Body(2),   Footer(3)]

Index pairing:     src[0]→cln[0]  src[1]→cln[1]    src[2]→cln[2]
Result:            Header→defs    Body→Header(!)    Footer→Body(!)
```

### Solution

Use `cache.session.nodeMap` — populated during `deepClone` for every cloned node — to look up each clone child's source element directly:

```javascript
const nodeMap = cache.session.nodeMap
for (const cChild of cloneNode.children) {
  const srcChild = nodeMap.get(cChild)
  if (!srcChild) continue  // clone-only element, skip
  queue.push([srcChild, cChild])
}
```

Clone-only elements (inline-defs-container, pseudo element spans, style tags) have no `nodeMap` entry and are naturally skipped. Shadow DOM hosts retain the existing index-based fallback since their source children live in `shadowRoot`.

### Tests

Added 3 test cases to `module.background.test.js`:
- Skips injected SVG and applies gradient to correct clone child
- Pairs correctly without injected elements
- Skips multiple injected elements at various positions