### PR TITLE
fix(fonts): scan the capture element's ownerDocument so iframe fonts embed (#441)

### DIFF
--- a/__tests__/module.fonts.iframe.test.js
+++ b/__tests__/module.fonts.iframe.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { embedCustomFonts } from '../src/modules/fonts.js'
+import { snapdom } from '../src/api/snapdom.js'
+import { cache } from '../src/core/cache.js'
+
+// #441: when the capture root lives inside a same-origin iframe, embedFonts must
+// scan the iframe's document for @font-face sources — not the parent document.
+
+const FAMILY = 'IframeProbeFont'
+// A data: src passes through embedCustomFonts untouched (no network fetch), so it
+// is a stable marker that the @font-face was actually found and inlined.
+const FONT_DATA_URL = 'data:font/woff2;base64,AAAA'
+
+function makeRequired(family, weight = '400', style = 'normal', stretchPct = 100) {
+  return new Set([`${family}__${weight}__${style}__${stretchPct}`])
+}
+
+function makeUsedCodepoints(text = 'A') {
+  const s = new Set()
+  for (const ch of text) s.add(ch.codePointAt(0))
+  return s
+}
+
+function makeIframeWithFont() {
+  const iframe = document.createElement('iframe')
+  iframe.style.cssText = 'width:240px;height:120px;border:0'
+  document.body.appendChild(iframe)
+  const doc = iframe.contentDocument
+  doc.open()
+  doc.write(
+    '<!doctype html><html><head><style>' +
+    `@font-face{font-family:'${FAMILY}';font-style:normal;font-weight:400;` +
+    `src:url(${FONT_DATA_URL}) format('woff2');}` +
+    '</style></head><body style="margin:0">' +
+    `<div id="root" style="font-family:'${FAMILY}',sans-serif;font-size:20px">Hello iframe fonts</div>` +
+    '</body></html>'
+  )
+  doc.close()
+  return { iframe, doc }
+}
+
+describe('embedCustomFonts — same-origin iframe document (#441)', () => {
+  let iframe
+
+  beforeEach(() => {
+    // The fonts result cache is keyed by required/exclude/etc. (not by document),
+    // so clear it between cases to keep the parent/iframe runs independent.
+    cache.font?.clear?.()
+    cache.resource?.clear?.()
+  })
+
+  afterEach(() => {
+    if (iframe?.parentNode) iframe.parentNode.removeChild(iframe)
+    iframe = null
+  })
+
+  it('embeds the iframe @font-face when doc is the iframe document', async () => {
+    const made = makeIframeWithFont()
+    iframe = made.iframe
+
+    const css = await embedCustomFonts({
+      required: makeRequired(FAMILY),
+      usedCodepoints: makeUsedCodepoints('Hello'),
+      doc: made.doc,
+    })
+
+    expect(css).toContain(FAMILY)
+    expect(css).toMatch(/data:font\/woff2/)
+  })
+
+  it('finds nothing when scanning the parent document (the pre-#441 behavior)', async () => {
+    const made = makeIframeWithFont()
+    iframe = made.iframe
+
+    const css = await embedCustomFonts({
+      required: makeRequired(FAMILY),
+      usedCodepoints: makeUsedCodepoints('Hello'),
+      // no `doc` → defaults to the parent `document`, which has no such @font-face
+    })
+
+    expect(css).not.toContain(FAMILY)
+  })
+
+  it('snapdom(root, { embedFonts: true }) inlines the iframe font into the SVG', async () => {
+    const made = makeIframeWithFont()
+    iframe = made.iframe
+    const root = made.doc.getElementById('root')
+
+    const url = await snapdom.toRaw(root, { embedFonts: true })
+    const svg = decodeURIComponent(url.slice(url.indexOf(',') + 1))
+
+    expect(svg).toContain('@font-face')
+    expect(svg).toContain(FAMILY)
+  })
+})

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -157,13 +157,15 @@ export async function captureDOM(element, options) {
   if (options.embedFonts) {
     await new Promise((resolve) => {
       idle(async () => {
+        // #441: read fonts from the element's own document (same-origin iframe support)
+        const ownerDoc = state.element.ownerDocument || document
         const required = collectUsedFontVariants(state.element)
         const usedCodepoints = collectUsedCodepoints(state.element)
         if (isSafari()) {
           const families = new Set(
             Array.from(required).map((k) => String(k).split('__')[0]).filter(Boolean)
           )
-          await ensureFontsReady(families, 1)
+          await ensureFontsReady(families, 1, ownerDoc)
         }
         fontsCSS = await embedCustomFonts({
           required,
@@ -172,7 +174,8 @@ export async function captureDOM(element, options) {
           exclude: state.options.excludeFonts,
           localFonts: state.options.localFonts,
           useProxy: state.options.useProxy,
-          fontStylesheetDomains: state.options.fontStylesheetDomains
+          fontStylesheetDomains: state.options.fontStylesheetDomains,
+          doc: ownerDoc
         })
         resolve()
       }, { fast })

--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -615,6 +615,7 @@ async function collectFacesFromSheet(sheet, baseHref, emitFace, ctx) {
  * @param {Array<{family:string,src:string,weight?:string|number,style?:string,stretchPct?:number}>} [options.localFonts=[]]
  * @param {string}  [options.useProxy=""]
  * @param {string[]} [options.fontStylesheetDomains=[]]      // extra domains to fetch cross-origin CSS from (#309)
+ * @param {Document} [options.doc=document]                  // document to scan for @font-face sources (the element's ownerDocument for iframe support, #441)
  * @returns {Promise<string>} inlined @font-face CSS
  */
 export async function embedCustomFonts({
@@ -624,6 +625,7 @@ export async function embedCustomFonts({
   localFonts = [],
   useProxy = '',
   fontStylesheetDomains = [],
+  doc = document,
 } = {}) {
   // ---------- Normalize inputs ----------
   if (!(required instanceof Set)) required = new Set()
@@ -733,12 +735,12 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
   const importUrls = []
   const IMPORT_ANY_RE_LOCAL = IMPORT_ANY_RE
 
-  for (const styleTag of document.querySelectorAll('style')) {
+  for (const styleTag of doc.querySelectorAll('style')) {
     const cssText = styleTag.textContent || ''
     for (const m of cssText.matchAll(IMPORT_ANY_RE_LOCAL)) {
       const u = (m[2] || m[4] || '').trim()
       if (!u || isIconFont(u)) continue
-      const hasLink = !!document.querySelector(`link[rel="stylesheet"][href="${u}"]`)
+      const hasLink = !!doc.querySelector(`link[rel="stylesheet"][href="${u}"]`)
       if (!hasLink) importUrls.push(u)
     }
   }
@@ -747,14 +749,14 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
   const injectedLinks = []
   if (importUrls.length) {
     await Promise.all(importUrls.map((u) => new Promise((resolve) => {
-      if (document.querySelector(`link[rel="stylesheet"][href="${u}"]`)) return resolve(null)
-      const link = document.createElement('link')
+      if (doc.querySelector(`link[rel="stylesheet"][href="${u}"]`)) return resolve(null)
+      const link = doc.createElement('link')
       link.rel = 'stylesheet'
       link.href = u
       link.setAttribute('data-snapdom', 'injected-import')
       link.onload = () => resolve(link)
       link.onerror = () => resolve(null)
-      document.head.appendChild(link)
+      doc.head.appendChild(link)
       injectedLinks.push(link)
     })))
   }
@@ -764,7 +766,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
   // ---------- 1) External <link rel="stylesheet"> ----------
   // Snapshot BEFORE detaching the injected links so their @import'd font CSS is still
   // collected below, then remove them from <head> to keep the capture non-destructive.
-  const linkNodes = Array.from(document.querySelectorAll('link[rel="stylesheet"]')).filter(l => !!l.href)
+  const linkNodes = Array.from(doc.querySelectorAll('link[rel="stylesheet"]')).filter(l => !!l.href)
   for (const l of injectedLinks) { try { l.remove() } catch { /* ok */ } }
 
   for (const link of linkNodes) {
@@ -781,7 +783,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
       }
 
       if (sameOrigin) {
-        const sheet = Array.from(document.styleSheets).find(s => s.href === link.href)
+        const sheet = Array.from(doc.styleSheets).find(s => s.href === link.href)
         if (sheet) {
           try {
             const rules = sheet.cssRules || []
@@ -844,7 +846,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
     depth: 0
   }
 
-  for (const sheet of document.styleSheets) {
+  for (const sheet of doc.styleSheets) {
     if (sheet.href && linkNodes.some(l => l.href === sheet.href)) continue
     try {
       const rootHref = sheet.href || (location.origin + '/')
@@ -862,7 +864,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
 
   // ---------- 3) document.fonts with _snapdomSrc ----------
   try {
-    for (const f of document.fonts || []) {
+    for (const f of doc.fonts || []) {
       if (!f || !f.family || f.status !== 'loaded' || !f._snapdomSrc) continue
       const fam = String(f.family).replace(/^['"]+|['"]+$/g, '')
       if (isIconFont(fam)) continue
@@ -1028,20 +1030,21 @@ export function collectUsedCodepoints(root) {
  *
  * @param {Set<string>|string[]} families - Plain family names (e.g., "Mansalva", "Unbounded")
  * @param {number} [warmupRepetitions=2] - How many times to warm-up each family
+ * @param {Document} [doc=document] - Document whose fonts to await and warm up (the element's ownerDocument for iframe support)
  * @returns {Promise<void>}
  */
-export async function ensureFontsReady(families, warmupRepetitions = 2) {
-  try { await document.fonts.ready } catch {}
+export async function ensureFontsReady(families, warmupRepetitions = 2, doc = document) {
+  try { await doc.fonts.ready } catch {}
 
   const fams = Array.from(families || []).filter(Boolean)
   if (fams.length === 0) return
 
   const warmupOnce = () => {
-    const container = document.createElement('div')
+    const container = doc.createElement('div')
     container.style.cssText = 'position:absolute!important;left:-9999px!important;top:0!important;opacity:0!important;pointer-events:none!important;contain:layout size style;'
 
     for (const fam of fams) {
-      const span = document.createElement('span')
+      const span = doc.createElement('span')
       span.textContent = 'AaBbGg1234ÁÉÍÓÚçñ—∞'
       span.style.fontFamily = `"${fam}"`
       span.style.fontWeight = '700'
@@ -1054,10 +1057,10 @@ export async function ensureFontsReady(families, warmupRepetitions = 2) {
       container.appendChild(span)
     }
 
-    document.body.appendChild(container)
+    doc.body.appendChild(container)
     // Force layout
     container.offsetWidth
-    document.body.removeChild(container)
+    doc.body.removeChild(container)
   }
 
   for (let i = 0; i < Math.max(1, warmupRepetitions); i++) {


### PR DESCRIPTION
Fixes #441.

### Problem

When the capture root lives inside a same-origin iframe, `embedFonts: true` does not embed that iframe's fonts. The output renders text with a fallback font even though the `@font-face` rules are present and loaded inside the iframe.

`collectUsedFontVariants()` reads the capture element, so it correctly works out which families are needed. But `embedCustomFonts()` then looked for those `@font-face` rules in the global `document`, not in `element.ownerDocument`, so `fontsCSS` came back empty.

This mirrors the measurement fix in #371, where `capture.js` was made to read `state.element.ownerDocument` for sizing. Font embedding was missed at the time.

### Change

Thread an optional `doc` (default `document`) through font discovery and pass the capture element's document from `capture.js`:

- `embedCustomFonts({ ..., doc = document })` now uses `doc` for the `style`/`link` `querySelectorAll`, the temporary `@import` `<link>` injection, `styleSheets`, and `document.fonts` reads.
- `ensureFontsReady(families, warmupRepetitions, doc = document)` uses `doc` for `fonts.ready` and the warm-up spans.
- `capture.js` computes `const ownerDoc = state.element.ownerDocument || document` and passes it to both.

`collectUsedFontVariants` / `collectUsedCodepoints` already work across documents (they walk the given root and read computed styles), so detection was already correct; only the embedding side needed the document.

### Scope

This targets same-origin iframes. The same-origin checks in `embedCustomFonts` (and `isLikelyFontStylesheet`) still compare against the parent `location`, which is correct because a same-origin iframe shares the parent origin. Cross-origin Google Fonts stylesheets continue to flow through the existing `isLikelyFontStylesheet` allowlist plus `snapFetch`, unchanged.

### Tests

Added `__tests__/module.fonts.iframe.test.js` (same-origin iframe):

1. `embedCustomFonts({ doc: iframeDoc })` embeds the iframe's `@font-face`, while the default (parent `document`) finds nothing.
2. A full `snapdom(root, { embedFonts: true })` capture of an element inside the iframe inlines the `@font-face` into the SVG.

Verified locally:

- The new tests fail on `main` (the bug) and pass with this change.
- The full suite passes: `551 passed, 1 skipped`.
- Also verified the cross-origin Google Fonts `<link>` path end to end with a network test (a `fonts.googleapis.com` link injected into the iframe head, captured from the parent, inlines the gstatic woff2). Not committed since it needs the network.

### One open question

`buildFontsCacheKey()` does not include `doc`, so two captures with the same `required` set but different documents would share a cache entry. In practice the required families differ per document so this is unlikely, and I kept the change minimal to match #371. Happy to add a document discriminator to the cache key if you would prefer.
