### PR TITLE
fix(capture): drop *-prefixed attributes to keep XMLSerializer output well-formed

### DIFF
--- a/__tests__/snapdom.starAttributes.test.js
+++ b/__tests__/snapdom.starAttributes.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { snapdom } from '../src/index'
+
+describe('*-prefixed HTML attributes', () => {
+  let host
+  beforeEach(() => { host = document.createElement('div'); document.body.appendChild(host) })
+  afterEach(() => host.remove())
+
+  it('does not throw EncodingError when an element has an *-prefixed attribute', async () => {
+    const el = document.createElement('div')
+    el.setAttribute('*ngIf', 'true')
+    el.setAttribute('*ngFor', 'let item of items')
+    el.setAttribute('*data-custom', 'value')
+    el.textContent = 'inside'
+    host.appendChild(el)
+
+    const canvas = await snapdom.toCanvas(host, { scale: 1, dpr: 1 })
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement)
+  })
+
+  it('produces an SVG with no *-prefixed attributes', async () => {
+    const el = document.createElement('span')
+    el.setAttribute('*ngIf', 'true')
+    el.setAttribute('*custom-attr', 'value')
+    el.textContent = 'hi'
+    host.appendChild(el)
+
+    const raw = await snapdom.toRaw(host)
+    const svg = decodeURIComponent(raw.replace(/^data:image\/svg\+xml;charset=utf-8,/, ''))
+    expect(svg).not.toMatch(/\*\w/)
+  })
+})

--- a/src/utils/capture.helpers.js
+++ b/src/utils/capture.helpers.js
@@ -152,6 +152,8 @@ export function sanitizeAttributesForXHTML(root, opts = {}) {
     for (const attr of Array.from(el.attributes)) {
       const name = attr.name
 
+      if (name.startsWith('*')) { el.removeAttribute(name); continue }
+
       // "@": never valid in XML attribute names
       if (name.includes('@')) { el.removeAttribute(name); continue }
 


### PR DESCRIPTION
## Summary

Fixes #446.

HTML attribute names beginning with `*` (e.g. Angular structural directives like `*ngIf`, `*ngFor`, or any custom `*data-foo`) are valid in HTML5 but illegal in XML — `*` is not a `NameStartChar`. They survive cloning, get serialized by `XMLSerializer.serializeToString` into `<foreignObject>`, and the resulting data: URL is malformed. `img.decode()` then throws `EncodingError: The source image cannot be decoded.`.

## Problem

`sanitizeAttributesForXHTML` already strips attribute names that would break the XHTML serializer:

- `@` — never valid in XML
- unknown `:` prefixes (only `xml` / `xlink` allowed)
- framework directives (`x-*`, `v-*`, `:`, `on:*`, `bind:*`, `let:*`, `class:*`)

`*` is another `NameStartChar` violation but was missing from that pass. Browsers don't enforce XML rules on serialization, so this only blows up downstream at `img.decode()`. Any Angular app — or any code that calls `setAttribute('*name', …)` — hits this.

## Change

Add a single rule to `sanitizeAttributesForXHTML`:

```js
if (name.startsWith('*')) { el.removeAttribute(name); continue }
```

Placed **outside** the `stripFrameworkDirectives` opt-out because it's an XML-spec rule, not a framework convention — `*` should always be stripped regardless of options.

`__tests__/snapdom.starAttributes.test.js`:

- reproduces the EncodingError on a node with `*ngIf` / `*ngFor` / `*data-custom`
- asserts the serialized SVG contains no `*`-prefixed attributes

## Test plan

- [x] New tests fail on `main` (`EncodingError` + `*`-attrs present in SVG)
- [x] New tests pass with this change
- [x] Full suite: `npx vitest run --browser.headless` → **553 passed, 1 skipped, 0 failed**
- [x] `npm run lint` clean
- [x] Cross-checked with related tests: `snapdom.attributes.test.js`, `snapdom.invalidXMLChars.test.js` pass unchanged