### PR TITLE
docs: refine Simplified Chinese documentation

### DIFF
--- a/CHINESE_TRANSLATION_GUIDE.md
+++ b/CHINESE_TRANSLATION_GUIDE.md
@@ -1,0 +1,183 @@
+# Simplified Chinese Documentation Translation Guide
+
+This document is a reusable reference for people and AI systems maintaining SnapDOM's Simplified Chinese documentation. It records translation decisions established during the technical review requested in [Discussion #450](https://github.com/zumerlab/snapdom/discussions/450) and refined in [PR #455](https://github.com/zumerlab/snapdom/pull/455).
+
+> This is a translation-maintenance guide, not an `AGENTS.md`, `SKILL.md`, prompt, or tool configuration. It does not override the repository's contribution rules.
+
+## Scope
+
+The maintained document pairs are:
+
+| English source | Simplified Chinese translation |
+|---|---|
+| [`README.md`](README.md) | [`README_CN.md`](README_CN.md) |
+| [`FEATURES.md`](FEATURES.md) | [`FEATURES_CN.md`](FEATURES_CN.md) |
+
+The English documents define the intended structure and feature coverage. The implementation remains the source of truth for runtime behavior, option defaults, browser workarounds, and API semantics.
+
+## Core principles
+
+1. **Translate meaning, not sentence structure.** Chinese prose should read as if it were originally written for front-end developers in China.
+2. **Preserve technical identifiers exactly.** Do not translate or rewrite API names, option keys, package paths, hooks, HTML tags, CSS properties, CSS values, or code symbols.
+3. **Preserve verified human edits.** When syncing a later English change, update the affected Chinese passage instead of regenerating an entire file.
+4. **Keep both Chinese documents consistent.** A recurring term should use the same translation in `README_CN.md` and `FEATURES_CN.md` unless the context genuinely requires different wording.
+5. **Verify technical claims against code.** If the English wording is ambiguous, inspect the implementation before translating it.
+6. **Prefer an explanation over a misleading literal term.** For example, describe visual content that extends outside an element's bounds instead of translating `bleed` mechanically as “出血”.
+
+## What must remain unchanged
+
+Keep these items byte-for-byte equivalent to the English source unless the code itself changes:
+
+- executable code in fenced code blocks;
+- import paths such as `@zumer/snapdom/preCache`;
+- API and method names such as `snapdom`, `preCache`, `toPng`, and `download`;
+- option names such as `outerShadows`, `embedFonts`, and `useProxy`;
+- hook names such as `beforeClone` and `afterExport`;
+- HTML and SVG names such as `<foreignObject>`, `<canvas>`, and `shadowRoot`;
+- CSS syntax such as `backdrop-filter`, `counter()`, `background-clip: text`, and `::placeholder`;
+- URLs, issue numbers, version numbers, filenames, and benchmark values.
+
+Code comments and surrounding prose may be translated. After translating a comment, confirm that the executable part of the example is still unchanged.
+
+## Terminology decisions
+
+Use this table as the default glossary. Context still takes priority over mechanical replacement.
+
+| English concept or identifier | Preferred Chinese wording | Notes |
+|---|---|---|
+| DOM Capture Engine | DOM 截图引擎 | Use in the reader-facing introduction. |
+| capture | 捕获 | Use for the internal capture operation or pipeline. |
+| embed / embedded | 嵌入 | Example: 嵌入字体. |
+| inline / inlined | 内联 | Use when styles, images, or definitions are serialized into the output. |
+| rasterize | 光栅化 | Prefer over a literal or unexplained transliteration. |
+| cross-origin | 跨源 | Do not replace with the less precise “跨域”. |
+| CORS / proxy | 跨源 / 代理 | Preserve `useProxy` and other identifiers. |
+| `preCache` | `preCache` | It is a method name, not the general noun “预缓存”. Never translate it. |
+| Shadow DOM | Shadow DOM | Keep the established platform term in English. |
+| pseudo-element | 伪元素 | Use for `::before`, `::after`, and related concepts. |
+| computed style | 计算样式 | Avoid “样式快照” unless the snapshot action is the point. |
+| bounding box | 边界框 | Use a descriptive phrase when the geometry is more specific. |
+| fallback | 回退方案 | “备用” may be used for a concrete fallback asset. |
+| placeholder box | 占位框 | Use “占位空间” when the placeholder is intentionally invisible. |
+| tree-shakeable | 支持 Tree Shaking | Do not use “可摇树”. |
+| bleed | 超出元素边界的部分 / 边界扩展 | Choose the phrase that explains the actual behavior. |
+| drawn replacement | 等效的内联 SVG 图形 | For Firefox checkbox/radio rendering inside `<foreignObject>`. |
+
+When an identifier also resembles an English noun, its role decides the translation:
+
+- `preCache` as a method name stays `preCache`.
+- “warm the cache ahead of time” as a general action may be translated as “提前预热缓存”.
+
+## Chinese writing style
+
+- Use concise, direct sentences. Split long English sentences when that improves readability.
+- Prefer “你” over “您” so the tone stays consistent across developer-facing sections.
+- Avoid marketing-heavy phrases such as “最高级别的捕获质量” when a concrete technical description is available.
+- Avoid machine-translation expressions such as “可摇树”, “烘焙为真实文本”, “视觉剥离”, “门控”, or “节点谓词”.
+- Keep the structural em dash from the English documents as a single `—`. Do not convert it to the Chinese double em dash `——`.
+- Use Chinese punctuation in ordinary prose, but do not alter punctuation inside code, URLs, option values, or package paths.
+- Keep names such as SnapDOM, SVG, PNG, WebP, Canvas, Blob, Firefox, and Safari in their established forms.
+- Use code formatting for identifiers when Markdown structure allows it.
+
+## Maintaining source alignment
+
+The Chinese files should mirror the English documents structurally without becoming literal line-by-line translations.
+
+Preserve:
+
+- section order and heading depth;
+- table row order and option coverage;
+- fenced code block count and language tags;
+- links and link destinations;
+- list structure;
+- examples, defaults, limitations, and benchmark values.
+
+Chinese heading text may differ, so update the corresponding table-of-contents anchor whenever a heading changes.
+
+Do not silently add technical claims that do not exist in the English source or implementation. If the English source is inaccurate, report or fix the source separately instead of making only the Chinese document diverge.
+
+## Technical verification examples
+
+When a sentence describes behavior rather than wording, inspect the relevant implementation:
+
+- option defaults: [`src/core/context.js`](src/core/context.js);
+- capture and cloning behavior: [`src/core/capture.js`](src/core/capture.js) and [`src/core/clone.js`](src/core/clone.js);
+- Firefox checkbox/radio SVG replacement: [`src/utils/clone.helpers.js`](src/utils/clone.helpers.js);
+- images, fonts, backgrounds, and rasterization: [`src/modules/`](src/modules/);
+- export return types and behavior: [`src/exporters/`](src/exporters/).
+
+For example, “Firefox uses an equivalent inline SVG graphic for checkboxes and radio buttons” is grounded in the `<foreignObject>` workaround in `createCheckboxRadioReplacement()`. The translation should explain that behavior instead of using the vague phrase “自绘控件”.
+
+## Recommended update workflow
+
+1. Identify the exact English sections changed since the last Chinese sync.
+2. Read the surrounding Chinese section before editing so established wording is preserved.
+3. Inspect source code when the change mentions behavior, defaults, browser handling, or internal architecture.
+4. Translate the changed meaning into natural Simplified Chinese.
+5. Apply the same terminology decision to both Chinese documents where relevant.
+6. Compare headings, tables, code blocks, links, and anchors with the English source.
+7. Run the checks below.
+8. Request native-speaker review when a term has multiple plausible Chinese translations.
+
+## Validation checklist
+
+At minimum, run:
+
+```sh
+git diff --check
+rg -n '^#{1,6} ' README.md README_CN.md FEATURES.md FEATURES_CN.md
+```
+
+Review the structural counts:
+
+```sh
+for file in README.md README_CN.md FEATURES.md FEATURES_CN.md; do
+  awk '
+    /^#{1,6} / { headings++ }
+    /^```/ { fences++ }
+    /^\|/ { table_rows++ }
+    END {
+      printf "%s: headings=%d fences=%d table_rows=%d\n",
+        FILENAME, headings, fences, table_rows
+    }
+  ' "$file"
+done
+```
+
+Matching counts do not prove a correct translation, but mismatched counts usually reveal a dropped section, table row, or code fence.
+
+Also verify manually that:
+
+- executable code still matches the English examples;
+- external URLs are unchanged;
+- local file links resolve;
+- table-of-contents anchors point to real Chinese headings;
+- new options or limitations appear in both languages;
+- repeated terminology is consistent across both Chinese files.
+
+The following scan highlights known translation regressions for manual review:
+
+```sh
+rg -n '——|预缓存|跨域|可摇树|烘焙|视觉剥离|门控|谓词' README_CN.md FEATURES_CN.md
+```
+
+Treat matches as review prompts, not automatic failures. A term may still be valid in a different context.
+
+## Using AI responsibly
+
+- Give the AI both the English source and the current Chinese translation. Do not ask it to translate from the English file in isolation.
+- Ask it to preserve code identifiers and existing human-reviewed terminology explicitly.
+- Limit each pass to the changed sections when syncing a release.
+- Verify technical statements against the repository instead of trusting a plausible translation.
+- Have a Chinese reader review changes before describing them as manually verified.
+- If AI assistance is disclosed in a PR or discussion, name the tool or model accurately and distinguish AI drafting from human review.
+
+## Updating this guide
+
+This guide records defaults, not immutable language rules. When a native-speaker review intentionally changes a recurring term:
+
+1. update both Chinese documents where the term appears;
+2. update the glossary or style rule here;
+3. explain the decision in the PR so future contributors understand why it changed.
+
+When uncertain, keep the technical identifier, write a clear Chinese explanation around it, and ask for review rather than inventing a translation.

--- a/FEATURES_CN.md
+++ b/FEATURES_CN.md
@@ -1,6 +1,6 @@
 # SnapDOM — 功能特性
 
-**SnapDOM** 捕获、内嵌与导出能力的完整技术总览。SnapDOM 将 DOM 子树序列化为自包含的 SVG（通过 `<foreignObject>`），再栅格化为目标格式——超快速度、零依赖，100% 基于标准 Web API。
+本文完整介绍 **SnapDOM** 能够捕获、嵌入和导出的内容。SnapDOM 会通过 `<foreignObject>` 将 DOM 子树序列化为自包含的 SVG，再将其光栅化为目标格式。整个过程速度快、零依赖，完全基于标准 Web API。
 
 > 📖 完整 API、选项与指南：**[snapdom.dev/docs](https://snapdom.dev/docs/)**
 >
@@ -21,51 +21,51 @@
 
 ## 捕获与克隆
 
-逐节点深度克隆，为每个节点快照其计算样式，保留浏览器真实渲染的结果。
+SnapDOM 会逐节点深度克隆 DOM，并记录每个节点的计算样式，从而还原浏览器实际渲染的效果。
 
-- **Shadow DOM** —— 遍历 `shadowRoot`，提取并作用域化其 CSS，注入所需的 CSS 自定义属性，并通过 `assignedNodes({ flatten: true })` 解析 `<slot>` 内容（已标记 slot 子树以避免重复克隆）。
-- **同源 iframe** —— 内联栅格化（字体从 iframe 自身文档读取）。跨源 iframe 无法读取，会渲染为条纹占位（若关闭 `placeholders` 则为隐藏占位符）。
-- **`<canvas>`** —— 快照为 PNG `<img>`（含 Safari 安全重试），保留固有尺寸与 CSS 盒子尺寸。
-- **`<video>`** —— 将当前帧绘制为图片；回退到 `poster`；遵循 `object-fit: contain`。
-- **`<audio controls>`** —— 替换为按元素尺寸绘制的播放器模拟图。
-- **表单控件状态** —— 保留 `<input>` 的 `value` / `checked` / `indeterminate`、`<textarea>` 的值以及 `<select>` 的选中项。复制状态属性（`disabled`、`required`、`readonly`、`min`、`max`、`pattern`、`aria-invalid`），使 `:disabled`、`:required`、`:read-only`、`:invalid`、`:in-range` 样式得以渲染。保留 `::placeholder` 颜色。Firefox 的复选框/单选按钮使用绘制替换。
-- **`<img>`** —— 冻结 `srcset`，记录变换前尺寸，作者使用 `%`/`auto` 时冻结像素尺寸，保留 `object-fit` / `object-position`。
-- **SVG** —— 将绘制属性（fill、stroke 及其各长写、opacity 变体、fill/clip 规则、markers、visibility、display）复制为内联样式；被 `<use>` 引用的外部 `<defs>` / `<symbol>` 会被内联，使 `var()` 在使用处解析。
-- **滚动位置** —— 对已滚动的容器，通过平移内部内容并裁剪溢出来还原；调整 fixed/absolute 后代，并冻结 sticky 页眉/页脚。
-- **按设计跳过** —— `meta`、`script`、`noscript`、`title`、`link`、`template`、SnapDOM 沙箱以及嵌套的 `<foreignObject>`。
+- **Shadow DOM** — 遍历 `shadowRoot`，提取 CSS 并限定其作用域，补齐所需的 CSS 自定义属性，再通过 `assignedNodes({ flatten: true })` 解析 `<slot>` 中分配的内容（会标记插槽子树，避免重复克隆）。
+- **同源 iframe** — 在当前位置转为位图并嵌入，字体从 iframe 自身的文档中读取。跨源 iframe 无法读取，因此会显示为条纹占位框；关闭 `placeholders` 后则只保留不可见的占位空间。
+- **`<canvas>`** — 转存为 PNG 格式的 `<img>`（包含针对 Safari 的重试机制），并保留画布的固有尺寸和 CSS 盒模型尺寸。
+- **`<video>`** — 将当前帧绘制为图片；如果失败，则使用 `poster`；同时遵循 `object-fit: contain`。
+- **`<audio controls>`** — 按元素尺寸绘制播放器示意图来替代原控件。
+- **表单控件状态** — 保留 `<input>` 的 `value` / `checked` / `indeterminate`、`<textarea>` 的值，以及 `<select>` 的选中项。还会复制 `disabled`、`required`、`readonly`、`min`、`max`、`pattern`、`aria-invalid` 等状态属性，使 `:disabled`、`:required`、`:read-only`、`:invalid`、`:in-range` 等伪类样式能够正确渲染。`::placeholder` 的颜色也会保留。由于 Firefox 无法在 SVG `<foreignObject>` 中可靠渲染原生复选框和单选按钮，SnapDOM 会改用等效的内联 SVG 图形，并保留控件状态和强调色。
+- **`<img>`** — 固定 `srcset` 的解析结果，记录应用变换前的尺寸；当样式中使用 `%` 或 `auto` 时，将尺寸固定为像素值；同时保留 `object-fit` 和 `object-position`。
+- **SVG** — 将 `fill`、`stroke` 及其各子属性、透明度相关属性、`fill-rule` / `clip-rule`、marker、`visibility`、`display` 等绘制属性复制为内联样式。对于 `<use>` 引用的外部 `<defs>` / `<symbol>`，会将定义一并内联，使 `var()` 能在 `<use>` 所在位置正确解析。
+- **滚动位置** — 对已经滚动的容器，SnapDOM 会移动其内部内容并裁剪溢出区域，以还原当前滚动位置；同时调整 `fixed` / `absolute` 定位的后代元素，并将 `sticky` 页眉和页脚固定在当前显示位置。
+- **有意跳过的内容** — `meta`、`script`、`noscript`、`title`、`link`、`template`、SnapDOM 沙箱，以及嵌套的 `<foreignObject>`。
 
-不可渲染内容会被妥善处理：剔除非法 XML 控制字符、强制 `content-visibility` 为可见以捕获屏幕外内容、并中和根元素外边距。
+无法渲染的内容也会得到妥善处理：删除非法的 XML 控制字符，强制让 `content-visibility` 对应的屏幕外内容参与渲染，并将根元素的外边距归零。
 
 ## 样式
 
-- **计算样式内联** —— 每个节点的完整计算样式都会被快照，并去重为生成的 CSS 类以压缩输出。作者的内联样式会被替换为计算值，使样式表的 `!important` 依然生效。
-- **保留细节** —— text-decoration 各长写（line/color/style/thickness、underline-offset、skip-ink）、`-webkit-text-stroke` + `paint-order`，以及（内嵌字体时）font-feature/variation/kerning/variant/optical-sizing 设置。
-- **`counter()` / `counters()`** —— 完整的 CSS 计数器解析器（含嵌套的 counter-reset、counter-increment、counter-set 及 counter-style 格式化），用于伪元素 `content`。
-- **`-webkit-line-clamp` 与 `text-overflow: ellipsis`** —— 烘焙为真实文本（含 `…`），因为 Firefox 和 Safari 在 `<foreignObject>` 内不遵循它们。
-- **变换（transforms）** —— 读取基础及独立的 `translate`/`rotate`/`scale` 为总矩阵，并进行考虑变换原点的包围盒计算（见 `outerTransforms` 选项）。
-- **阴影、模糊与轮廓外溢** —— 当 `outerShadows` 开启时，box-shadow、filter 模糊、drop-shadow 与 outline 会扩展 viewBox；否则根阴影会被视觉剥离（见 `outerShadows`）。
-- **蒙版、背景与 border-image** —— 见[图片与背景](#图片与背景)。
-- **自定义滚动条** —— 注入 `::-webkit-scrollbar` 规则，使自定义滚动条样式显示出来。
-- **`excludeStyleProps`** —— 通过 RegExp 或谓词从快照中跳过某些属性（例如剔除所有 CSS 变量）。
+- **内联计算样式** — 固化每个节点的完整计算样式，再合并相同样式并生成 CSS 类，以减小输出体积。源元素上的内联样式会替换为计算后的值，确保样式表中的 `!important` 仍按浏览器计算结果生效。
+- **保留样式细节** — 保留 `text-decoration` 的具体属性（`line`、`color`、`style`、`thickness`、`underline-offset`、`skip-ink`）、`-webkit-text-stroke`、`paint-order`；嵌入字体时，还会保留字体特性、可变轴、字距调整、变体和光学尺寸等设置。
+- **`counter()` / `counters()`** — 内置完整的 CSS 计数器解析器，支持嵌套的 `counter-reset`、`counter-increment`、`counter-set` 和 `counter-style` 格式化，用于生成伪元素的 `content`。
+- **`-webkit-line-clamp` 与 `text-overflow: ellipsis`** — 直接转换为带 `…` 的实际文本，因为 Firefox 和 Safari 无法在 `<foreignObject>` 中正确应用这些样式。
+- **变换** — 将 `transform` 与独立的 `translate` / `rotate` / `scale` 合并为完整矩阵，并在计算边界框时考虑变换原点（见 `outerTransforms` 选项）。
+- **阴影、模糊和轮廓的边界扩展** — 开启 `outerShadows` 后，会扩大 `viewBox` 以容纳 `box-shadow`、`filter: blur()`、`drop-shadow()` 和 `outline` 超出元素边界的部分；否则会移除根元素上的这些视觉效果（见 `outerShadows`）。
+- **蒙版、背景与 `border-image`** — 见[图片与背景](#图片与背景)。
+- **自定义滚动条** — 注入 `::-webkit-scrollbar` 规则，使自定义滚动条样式显示出来。
+- **`excludeStyleProps`** — 通过正则表达式或判断函数跳过某些样式属性（例如排除所有 CSS 变量）。
 
 ## 图片与背景
 
-- **`<img>` 内联** —— 解析 `currentSrc`/`src`，拉取为 data URL、缓存并确保尺寸（分批以遵守 HTTP/1.1 连接数限制）。SVG `<image href>` 同样会内联。
-- **背景与蒙版** —— 内联 `background-image`（及 `background` 简写）、`mask` / `-webkit-mask*` 与 `border-image` 中的 `url()` 层，保留多层值与布局长写（position、size、repeat、origin、clip、blend-mode、composite……）。支持 `background-clip: text`。
-- **`<picture>` 与懒加载图片** —— 在克隆前将 `<picture>` 源与常见懒加载属性（`data-src`、`data-lazy-src`、`data-original`、`data-hi-res-src`、`data-srcset`……）解析为真实 URL。
-- **CORS / 代理** —— 一个不抛错的 fetch 层，具备进行中请求去重、错误缓存、超时与推断凭据。`useProxy` 接受灵活的模板（`{url}`、`{urlRaw}`、`?url=` 后缀等）；已代理的以及 `data:`/`blob:` URL 会被跳过。
-- **失败回退** —— 可配置的 `fallbackURL`（字符串或回调），然后是占位框，再然后是隐藏占位符。
-- **`compress`** —— 将内联栅格图感知式降采样至其可见分辨率（显示盒 × scale × dpr），保留源编码且永不放大。默认开启；设 `compress: false` 可原样嵌入。
-- **解码尺寸保护** —— SVG 栅格尺寸被限制在安全范围（每边最大 16384px，面积约 268M px），超出时会降采样并给出警告。
+- **内联 `<img>`** — 解析 `currentSrc` / `src`，获取图片并转为 Data URL，缓存结果，同时确保尺寸正确。请求会分批处理，以避免超过 HTTP/1.1 的连接数限制。SVG 的 `<image href>` 也会一并内联。
+- **背景与蒙版** — 内联 `background-image`（以及 `background` 简写）、`mask` / `-webkit-mask*` 和 `border-image` 中各层的 `url()`，保留多层值以及 `position`、`size`、`repeat`、`origin`、`clip`、`blend-mode`、`composite` 等相关布局属性。支持 `background-clip: text`。
+- **`<picture>` 与懒加载图片** — 克隆前，将 `<picture>` 的资源和常见懒加载属性（`data-src`、`data-lazy-src`、`data-original`、`data-hi-res-src`、`data-srcset` 等）解析为实际的资源 URL。
+- **跨源 / 代理** — 内置不会向外抛出异常的资源请求层，支持合并并发的相同请求、缓存错误、超时控制和自动判断凭据。`useProxy` 支持多种模板写法（`{url}`、`{urlRaw}`、以 `?url=` 结尾等）；已经过代理的 URL 以及 `data:` / `blob:` URL 会被跳过。
+- **加载失败时的回退方案** — 依次尝试可配置的 `fallbackURL`（字符串或回调）、占位框，最后保留不可见的占位空间。
+- **`compress`** — 按图片的实际显示分辨率（显示区域 × `scale` × `dpr`）对已内联的位图进行感知降采样，保留原始编码格式且绝不放大。默认开启；设置 `compress: false` 可原样嵌入图片数据。
+- **解码尺寸保护** — 将 SVG 光栅化时，尺寸会限制在安全范围内（单边最大 16384 px，总面积约 2.68 亿像素）；超出限制时会自动缩小并发出警告。
 
 ## 字体与图标字体
 
-- **`@font-face` 内嵌**（`embedFonts`）—— 扫描文档（及 iframe）样式表，仅内嵌**实际使用**的字族/字重/字形/拉伸对应的 `@font-face` 规则，并与**已使用的 Unicode 码点**取交集，从而保持体积精简。支持近似字重匹配与合成斜体回退。
-- **图标字体** —— 自动识别 Font Awesome、Material Icons / Symbols、Ionicons、Glyphicons、Feather、Bootstrap Icons、Remix、Heroicons、Layui 与 Lucide（外加启发式规则），并将字形（含连字图标）渲染为图片。可通过 `iconFonts` 选项或 `window.__SNAPDOM_ICON_FONTS__` 扩展识别。
-- **`localFonts`** —— 以 `{ family, src, weight?, style?, stretchPct? }` 提供你自己的字体以拉取并内嵌。
-- **`excludeFonts`** —— 按 `{ families?, domains?, subsets? }` 排除。
-- **跨源样式表** —— 由 `fontStylesheetDomains` 门控（外加已知数学库如 KaTeX/MathJax）。
-- **`preCache`** —— 在捕获前预加载图片、背景图片与字体；默认 `embedFonts: true` 且 `cache: 'full'`。
+- **嵌入 `@font-face`**（`embedFonts`） — 扫描文档和 iframe 中的样式表，只嵌入与**实际使用**的字体系列、字重、样式和拉伸比例相匹配的 `@font-face` 规则，并裁剪到**实际用到的 Unicode 码点**范围，从而减小输出体积。支持近似字重匹配，并可在缺少斜体字形时合成斜体。
+- **图标字体** — 自动识别 Font Awesome、Material Icons / Symbols、Ionicons、Glyphicons、Feather、Bootstrap Icons、Remix、Heroicons、Layui 和 Lucide，并通过补充规则识别其他图标字体；随后将字形（包括连字图标）渲染为图片。可通过 `iconFonts` 选项或 `window.__SNAPDOM_ICON_FONTS__` 扩展识别范围。
+- **`localFonts`** — 通过 `{ family, src, weight?, style?, stretchPct? }` 传入自定义字体信息，供 SnapDOM 获取并嵌入。
+- **`excludeFonts`** — 可按 `{ families?, domains?, subsets? }` 排除字体。
+- **跨源样式表** — `fontStylesheetDomains` 用于指定允许读取字体样式表的额外跨源域名；KaTeX、MathJax 等已知数学库也在支持范围内。
+- **`preCache`** — 捕获前预加载图片、背景图和字体；默认使用 `embedFonts: true` 和 `cache: 'full'`。
 
 ## 导出格式
 
@@ -76,13 +76,13 @@
 | `toRaw()` | 原始 `data:image/svg+xml` URL |
 | `toSvg()` / `toImg()` | SVG `HTMLImageElement` |
 | `toCanvas()` | `HTMLCanvasElement` |
-| `toBlob()` | `Blob`（SVG 文本 blob 或栅格） |
+| `toBlob()` | `Blob`（包含 SVG 文本或光栅化图像） |
 | `toPng()` | PNG 图片 |
 | `toJpg()` | JPG 图片（白色背景） |
 | `toWebp()` | WebP 图片 |
 | `download()` | 触发文件下载 |
 
-同名方法也提供一步式静态快捷方式（`snapdom.toPng(el)`、`snapdom.download(el)`……）。有损格式（JPEG/WebP）会将透明自动填充为白色。下载在 iOS 上回退到 Web Share API。导出通过每会话的串行队列执行，并带有 `beforeExport` / `afterExport` / `afterSnap` 钩子。
+同名方法也提供一次性静态快捷调用（`snapdom.toPng(el)`、`snapdom.download(el)` 等）。JPEG / WebP 等有损格式会自动用白色填充透明区域。iOS 上下载时会使用 Web Share API 作为回退方案。同一捕获会话内的导出任务会进入串行队列，并依次触发 `beforeExport` / `afterExport` / `afterSnap` 钩子。
 
 ## 选项
 
@@ -90,74 +90,74 @@
 
 | 选项 | 默认值 | 行为 |
 |---|---|---|
-| `debug` | `false` | 调试警告 |
-| `fast` | `true` | 跳过 idle 延迟以提速 |
+| `debug` | `false` | 输出调试警告 |
+| `fast` | `true` | 跳过空闲等待以提升速度 |
 | `scale` | `1` | 输出缩放倍数 |
-| `exclude` | `[]` | 要排除的 CSS 选择器 |
-| `excludeMode` | `'hide'` | `'hide'`（占位）或 `'remove'` |
-| `filter` | `null` | 节点谓词 `(node) => boolean` |
-| `filterMode` | `'hide'` | `'hide'` 或 `'remove'` |
-| `placeholders` | `true` | 为失败图片 / 跨源 iframe 显示占位符 |
-| `embedFonts` | `false` | 内嵌匹配的 `@font-face` |
-| `iconFonts` | `[]` | 额外的图标字体名称/正则 |
-| `localFonts` | `[]` | 用户字体描述符 |
-| `excludeFonts` | `undefined` | `{ families, domains, subsets }` |
-| `fontStylesheetDomains` | `[]` | 额外的跨源 CSS 域名 |
-| `fallbackURL` | `undefined` | 回退图片 URL 或回调 |
+| `exclude` | `[]` | 需要排除的 CSS 选择器 |
+| `excludeMode` | `'hide'` | `'hide'`（保留布局空间）或 `'remove'`（移除节点） |
+| `filter` | `null` | 节点过滤函数 `(node) => boolean` |
+| `filterMode` | `'hide'` | `'hide'`（保留布局空间）或 `'remove'`（移除节点） |
+| `placeholders` | `true` | 为加载失败的图片 / 跨源 iframe 显示占位符 |
+| `embedFonts` | `false` | 嵌入匹配的 `@font-face` |
+| `iconFonts` | `[]` | 额外的图标字体名称或正则表达式 |
+| `localFonts` | `[]` | 自定义字体描述信息 |
+| `excludeFonts` | `undefined` | 字体排除规则 `{ families, domains, subsets }` |
+| `fontStylesheetDomains` | `[]` | 允许读取字体样式表的额外跨源域名 |
+| `fallbackURL` | `undefined` | 备用图片 URL 或回调 |
 | `cache` | `'soft'` | `disabled` / `soft` / `auto` / `full` |
-| `useProxy` | `''` | CORS 代理模板/基址 |
+| `useProxy` | `''` | 跨源代理模板或基础地址 |
 | `width` | `null` | 输出宽度（保持宽高比） |
 | `height` | `null` | 输出高度 |
-| `format` | `'png'` | `png` / `jpg`→`jpeg` / `webp` / `svg` |
+| `format` | `'png'` | `png` / `jpg` → `jpeg` / `webp` / `svg` |
 | `type` | `'svg'` | 输出类型 `svg` / `img` / `canvas` / `blob` |
 | `quality` | `0.92` | 有损编码质量 |
 | `dpr` | `devicePixelRatio \|\| 1` | 设备像素比 |
-| `backgroundColor` | `null`（jpeg/webp 为 `#ffffff`） | 扁平化背景 |
-| `filename` | `'snapDOM'` | 下载文件名基础 |
-| `outerTransforms` | `true` | 归一化根 translate/rotate 还是为变换扩展包围盒 |
-| `outerShadows` | `false` | 剥离根阴影还是为阴影/模糊/轮廓扩展外溢 |
-| `compress` | `true` | 感知式栅格降采样 |
+| `backgroundColor` | `null`（jpeg/webp 为 `#ffffff`） | 背景填充色 |
+| `filename` | `'snapDOM'` | 下载文件名（不含扩展名） |
+| `outerTransforms` | `true` | 规范化根元素的位移/旋转，或扩展边界以容纳变换 |
+| `outerShadows` | `false` | 移除根元素的阴影，或扩展边界以容纳阴影/模糊/轮廓 |
+| `compress` | `true` | 按实际显示分辨率缩小已内联的位图 |
 | `safariWarmupAttempts` | `3` | Safari 预热次数（1–3） |
-| `excludeStyleProps` | `null` | 跳过样式属性的 RegExp/谓词 |
+| `excludeStyleProps` | `null` | 用于跳过样式属性的正则表达式或判断函数 |
 | `resolvePicturePlaceholders` | `true` | 内置 `<picture>` / 懒加载解析器 |
 | `pictureResolver` | `{}` | `{ timeout, concurrency, resolveLazySrc, silent }` |
-| `plugins` | — | 每次捕获的插件列表（本地优先） |
+| `plugins` | — | 当前捕获使用的插件列表（局部插件优先） |
 
 ## 插件系统
 
-插件是带生命周期钩子的普通对象，可全局注册（`snapdom.plugins(...)`，按 `name` 去重）或按次捕获注册（`{ plugins: [...] }`，本地按名称覆盖全局）。
+插件是包含生命周期钩子的普通对象，可以全局注册（`snapdom.plugins(...)`，按 `name` 去重），也可以只为单次捕获注册（`{ plugins: [...] }`，同名的局部插件会覆盖全局插件）。
 
 - **钩子**（按顺序）：`beforeSnap → beforeClone → afterClone → beforeRender → afterRender → beforeExport → afterExport → afterSnap`。
-- **自定义导出器** —— 插件的 `defineExports` 可新增或覆盖导出格式；每个都会在结果对象上生成一个 `to<Name>()` 辅助方法，并获得与核心格式相同的导出流程。
-- **接受的形式** —— 普通对象、`[factory, options]`、`{ plugin, options }` 或工厂函数。
+- **自定义导出方法** — 插件的 `defineExports` 可以新增或覆盖导出格式；每种格式都会在结果对象上生成对应的 `to<Name>()` 方法，并复用与内置格式相同的导出流程。
+- **支持的写法** — 普通对象、`[factory, options]`、`{ plugin, options }` 或工厂函数。
 
 参见 [`PLUGIN_SPEC.md`](PLUGIN_SPEC.md) 与 [`CONTRIBUTING_PLUGINS.md`](CONTRIBUTING_PLUGINS.md)。
 
 ## 缓存与 preCache
 
-- **缓存桶** —— 用于 `image`、`background`、`resource`、`baseStyle` 与 `defaultStyle` 的 FIFO 淘汰映射；用于计算样式与布局测量提示的 `WeakMap`；用于字体的 `Set`；以及一个每会话缓存桶。
+- **缓存区** — `image`、`background`、`resource`、`baseStyle` 和 `defaultStyle` 使用按 FIFO 顺序淘汰的 `Map`；计算样式和布局测量提示使用 `WeakMap`；字体使用 `Set`；此外还有本次捕获会话专用的缓存区。
 - **策略**（`cache` 选项）：
-  - `disabled` —— 每次捕获清空所有缓存。
-  - `soft`（默认）—— 重置会话的样式/节点映射，保留持久缓存。
-  - `auto` —— 仅重置样式/节点映射，同时也保留样式缓存。
-  - `full` —— 保留一切。
-- **失效机制** —— DOM 与 `<head>` 上的 MutationObserver 加上字体 `loadingdone`/`ready` 事件会提升样式快照的 epoch，从而自动丢弃过期快照。
-- **`preCache`** —— 提前预热缓存（默认 `cache: 'full'`）。
+  - `disabled` — 每次捕获清空所有缓存。
+  - `soft`（默认） — 重置当前会话的样式/节点映射，保留持久缓存。
+  - `auto` — 只重置样式/节点映射，连样式缓存也会保留。
+  - `full` — 保留一切。
+- **失效机制** — DOM 和 `<head>` 上的 `MutationObserver`，以及字体的 `loadingdone` / `ready` 事件，都会递增样式快照的版本号（epoch），从而自动丢弃过期快照。
+- **`preCache`** — 提前预热缓存（默认 `cache: 'full'`）。
 
 ## 跨浏览器处理
 
-- **Safari 预热** —— 规避 [WebKit #219770](https://bugs.webkit.org/show_bug.cgi?id=219770)（首次绘制含内嵌字体的 SVG 到 canvas 时是空白）：当内嵌字体或元素含背景/蒙版/canvas 内容时，运行小型预捕获 + `drawImage` 来预热管道。可通过 `safariWarmupAttempts` 配置。
-- **Safari canvas** —— 将 box-shadow 改写为 SVG drop-shadow，并在绘制前等待图片合成完成。
-- **Firefox** —— 复选框与单选按钮使用绘制替换。
-- **iOS** —— `download()` 回退到 Web Share API。
+- **Safari 预热** — 针对 [WebKit #219770](https://bugs.webkit.org/show_bug.cgi?id=219770) 提供规避方案：第一次把带嵌入字体的 SVG 绘制到 canvas 上时，内容可能为空。嵌入字体，或元素包含背景、蒙版、canvas 内容时，SnapDOM 会先执行少量预捕获并调用 `drawImage` 来预热渲染流程。预热次数可通过 `safariWarmupAttempts` 配置。
+- **Safari canvas** — 将 `box-shadow` 转换为 SVG `drop-shadow`，并在绘制前等待图片合成完成。
+- **Firefox** — 原生复选框和单选按钮无法在 SVG `<foreignObject>` 中可靠渲染时，改用等效的内联 SVG 图形。
+- **iOS** — `download()` 无法直接下载时，改用 Web Share API。
 
 ## 节点级控制属性
 
-直接在标记中进行精细控制：
+可以直接在 HTML 标记中精细控制节点的捕获方式：
 
-- `data-capture="exclude"` —— 丢弃该节点（按 `excludeMode`）。
-- `data-capture="placeholder"` + `data-placeholder-text` —— 渲染占位框而非该节点。
-- `data-snapdom-sandbox` / `#snapdom-sandbox` —— 完全跳过。
+- `data-capture="exclude"` — 按 `excludeMode` 隐藏或移除该节点。
+- `data-capture="placeholder"` + `data-placeholder-text` — 用占位框替代该节点。
+- `data-snapdom-sandbox` / `#snapdom-sandbox` — 完全不参与捕获。
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,18 +33,16 @@
 </p>
 <p align="center"><a href="README.md">English</a> | 简体中文</p>
 
-# snapDOM
+# SnapDOM
 
-**SnapDOM** 是新一代的 **DOM 捕获引擎（DOM Capture Engine）**——是 **html2canvas**、**dom-to-image** 和 **html-to-image** 的快速、现代替代方案。  
-它可以将任意 DOM 子树转换为自包含的结构，并导出为 SVG、PNG、JPG、WebP、Canvas、Blob，或通过插件系统生成 **任何自定义格式**——超高速、模块化、可扩展、零依赖。
-
-SnapDOM 会保留样式、字体、背景图像、伪元素、Shadow DOM 等所有视觉特性，并通过可扩展的架构实现强大的灵活性和最高级别的捕获质量。
+**SnapDOM** 是新一代的 **DOM 截图引擎**，也是 **html2canvas**、**dom-to-image** 和 **html-to-image** 的快速、现代替代方案。
+它能把任意 DOM 子树连同浏览器实际渲染出的样式、字体、图片和伪元素一起打包，生成不依赖原页面的结果，再导出为 SVG、PNG、JPG、WebP、Canvas 或 Blob；还可以通过插件导出为**任意自定义格式**。整个引擎速度快、模块化、易扩展，而且零依赖。
 
 > 📖 **[文档、指南与在线演示 → snapdom.dev](https://snapdom.dev)**
 
 ## 功能特性
 
-完整的 DOM 捕获，内嵌样式、伪元素和字体；导出为 SVG、PNG、JPG、WebP、`canvas` 或 Blob——超快速度、零依赖，100% 基于标准 Web API。
+完整捕获 DOM，并嵌入样式、伪元素和字体；可导出为 SVG、PNG、JPG、WebP、`canvas` 或 Blob。速度快、零依赖，完全基于标准 Web API。
 
 👉 **完整的技术功能清单见 [FEATURES_CN.md](FEATURES_CN.md)。**
 
@@ -90,48 +88,48 @@ await result.download({ format: 'jpg', filename: 'card.jpg' });
 - [贡献者](#贡献者)
 - [赞助者](#赞助者)
 - [支持我们](#支持我们)
-- [Star 历史](#star-历史)
+- [Star 趋势](#star-趋势)
 - [许可证](#许可证)
 
 ## 安装
 
-### NPM / Yarn (稳定版)
+### NPM / Yarn（稳定版）
 
 ```bash
 npm i @zumer/snapdom
 yarn add @zumer/snapdom
 ```
 
-### NPM / Yarn (开发版)
+### NPM / Yarn（开发版）
 
-想要提前体验新功能和修复：
+如需提前体验新功能和修复：
 
 ```bash
 npm i @zumer/snapdom@dev
 yarn add @zumer/snapdom@dev
 ```
 
-⚠️ `@dev` 标签通常包含在正式发布前的改进，但可能不够稳定。
+⚠️ `@dev` 标签通常会提前包含尚未发布的改进，但稳定性可能不及正式版。
 
-### CDN (稳定版)
+### CDN（稳定版）
 
 ```html
-<!-- 压缩的 构建 -->
+<!-- 压缩版 -->
 <script src="https://unpkg.com/@zumer/snapdom/dist/snapdom.js"></script>
 
-<!-- ES 模块构建 -->
+<!-- 压缩版 ES Module -->
 <script type="module">
   import { snapdom } from "https://unpkg.com/@zumer/snapdom/dist/snapdom.mjs";
 </script>
 ```
 
-### CDN (开发版)
+### CDN（开发版）
 
 ```html
-<!-- 压缩的 UMD 构建（开发版） -->
+<!-- 压缩版（开发版） -->
 <script src="https://unpkg.com/@zumer/snapdom@dev/dist/snapdom.js"></script>
 
-<!-- ES 模块构建（开发版） -->
+<!-- 压缩版 ES Module（开发版） -->
 <script type="module">
   import { snapdom } from "https://unpkg.com/@zumer/snapdom@dev/dist/snapdom.mjs";
 </script>
@@ -142,21 +140,21 @@ yarn add @zumer/snapdom@dev
 
 | 变体 | 文件 | 使用场景 |
 |------|------|----------|
-| **ESM**（可摇树） | `dist/snapdom.mjs` | 打包工具（Vite、webpack），`import` |
-| **IIFE**（全局） | `dist/snapdom.js` | script 标签、传统 `require` |
+| **ESM**（支持 Tree Shaking） | `dist/snapdom.mjs` | 打包工具（Vite、webpack）、`import` |
+| **IIFE**（全局变量） | `dist/snapdom.js` | `<script>` 标签、传统 `require` |
 
-**打包工具 (npm)：**
+**打包工具（npm）：**
 ```js
 import { snapdom } from '@zumer/snapdom';  // → dist/snapdom.mjs
 ```
 
-**script 标签 (CDN)：**
+**`<script>` 标签（CDN）：**
 ```html
 <script src="https://unpkg.com/@zumer/snapdom/dist/snapdom.js"></script>
 <script> snapdom.toPng(document.body).then(img => document.body.appendChild(img)); </script>
 ```
 
-**子路径导入**（仅需部分功能时可减小体积）：
+**子路径导入**（只使用部分功能时，打包体积更小）：
 ```js
 import { preCache } from '@zumer/snapdom/preCache';
 import { plugins } from '@zumer/snapdom/plugins';
@@ -167,12 +165,12 @@ import { plugins } from '@zumer/snapdom/plugins';
 
 | 模式 | 适用场景 |
 |------|----------|
-| **可复用** `snapdom(el)` | 一次克隆 → 多次导出（PNG + JPG + 下载）。 |
-| **快捷** `snapdom.toPng(el)` | 单次导出，代码更简洁。 |
+| **可复用调用** `snapdom(el)` | 克隆一次，多次导出（如 PNG、JPG 和下载）。 |
+| **快捷方法** `snapdom.toPng(el)` | 只导出一次，代码更简洁。 |
 
-### 可复用的捕获
+### 可复用捕获
 
-一次捕获，多次导出（不会重新克隆）：
+捕获一次，多次导出（无需重复克隆）：
 
 ```js
 const el = document.querySelector('#target');
@@ -183,9 +181,9 @@ document.body.appendChild(img);
 await result.download({ format: 'jpg', filename: 'my-capture.jpg' });
 ```
 
-### 一步式快捷方法
+### 一次性快捷方法
 
-直接导出单一格式：
+只需要一种格式时，可直接导出：
 
 ```js
 const png = await snapdom.toPng(el);
@@ -195,12 +193,12 @@ document.body.appendChild(png);
 
 ## 文档
 
-完整参考托管在 **[snapdom.dev/docs](https://snapdom.dev/docs/)**，以保持同步且可搜索：
+完整参考文档位于 **[snapdom.dev/docs](https://snapdom.dev/docs/)**，会随版本同步更新，也支持站内搜索：
 
-- **[API 参考](https://snapdom.dev/docs/api/)** — `snapdom()` 可复用对象、快捷方法和导出器专用选项。
-- **[选项](https://snapdom.dev/docs/options/)** — 每个捕获选项（`scale`、`dpr`、`embedFonts`、`useProxy`、`exclude`/`filter`、`compress`、`outerTransforms`、`outerShadows`、`cache`…）均附示例说明。
-- **[插件](https://snapdom.dev/docs/plugins/)** — 构建、注册并发布自定义插件和导出格式。社区插件见[插件页面](https://snapdom.dev/plugins.html)。
-- **[缓存与 preCache](https://snapdom.dev/docs/cache/)** — 控制捕获之间的缓存并预加载资源。
+- **[API 参考](https://snapdom.dev/docs/api/)** — `snapdom()` 返回的可复用对象、快捷方法，以及各导出方法的专用选项。
+- **[选项](https://snapdom.dev/docs/options/)** — 逐项介绍所有捕获选项（`scale`、`dpr`、`embedFonts`、`useProxy`、`exclude`/`filter`、`compress`、`outerTransforms`、`outerShadows`、`cache`……），并附有示例。
+- **[插件](https://snapdom.dev/docs/plugins/)** — 如何构建、注册和发布自定义插件及导出格式。社区插件见[插件页面](https://snapdom.dev/plugins.html)。
+- **[缓存与 preCache](https://snapdom.dev/docs/cache/)** — 控制多次捕获之间的缓存，并通过 `preCache` 提前加载所需资源。
 
 ### API 速览
 
@@ -208,9 +206,9 @@ document.body.appendChild(png);
 
 | 方法 | 说明 |
 | ------------------------------ | --------------------------------- |
-| `snapdom.toSvg(el, options?)`  | 返回 SVG `HTMLImageElement` |
-| `snapdom.toCanvas(el, options?)` | 返回 `Canvas`                    |
-| `snapdom.toBlob(el, options?)` | 返回 SVG 或栅格 `Blob`            |
+| `snapdom.toSvg(el, options?)`  | 返回包含 SVG 的 `HTMLImageElement` |
+| `snapdom.toCanvas(el, options?)` | 返回 `HTMLCanvasElement`        |
+| `snapdom.toBlob(el, options?)` | 返回包含 SVG 或位图数据的 `Blob`  |
 | `snapdom.toPng(el, options?)`  | 返回 PNG 图片                     |
 | `snapdom.toJpg(el, options?)`  | 返回 JPG 图片                     |
 | `snapdom.toWebp(el, options?)` | 返回 WebP 图片                    |
@@ -220,38 +218,38 @@ document.body.appendChild(png);
 
 ## 限制
 
-* 外部图片应该是 CORS 可访问的（使用 `useProxy` 选项处理 CORS 拒绝）
-* 在 Safari 上使用 WebP 格式时，将回退到 PNG 渲染。
-* `@font-face` CSS 规则得到良好支持，但如果需要使用 JS `FontFace()`，请参阅此解决方案 [`#43`](https://github.com/zumerlab/snapdom/issues/43)
-* **Safari**：启用 `embedFonts` 或包含背景/蒙版图片的捕获会较慢，因 [WebKit #219770](https://bugs.webkit.org/show_bug.cgi?id=219770)（字体解码时机）。SnapDOM 通过预捕获和 `drawImage` 预热管道；可通过 `safariWarmupAttempts` 调整（默认 3）。
-* **自定义滚动条样式**（`::-webkit-scrollbar`）：仅在元素*未滚动*时生效。若已滚动，将捕获视口内容且不显示滚动条。
+* 外部图片需要允许跨源访问；如果被跨源拦截，可使用 `useProxy` 选项。
+* Safari 不支持以 WebP 导出时，会回退为 PNG。
+* SnapDOM 对 `@font-face` CSS 规则的支持较完善；如需使用 JavaScript `FontFace()`，请参阅 [`#43`](https://github.com/zumerlab/snapdom/issues/43) 中的解决方案。
+* **Safari**：启用 `embedFonts`，或待捕获元素包含背景图/蒙版图时，受 [WebKit #219770](https://bugs.webkit.org/show_bug.cgi?id=219770)（字体解码时机）影响，捕获速度会变慢。SnapDOM 会预先执行少量捕获并调用 `drawImage` 来预热渲染流程；预热次数可通过 `safariWarmupAttempts` 调整（默认为 3）。
+* **自定义滚动条样式**（`::-webkit-scrollbar`）：仅当元素**尚未滚动**时保留。元素滚动后，SnapDOM 会捕获当前视口中的内容，但不会包含滚动条。
 
 
 ## 性能基准测试
 
-**设置说明。** 在 Chromium 上使用 Vitest 基准测试，仓库测试。硬件可能影响结果。
-数值为**平均捕获时间（毫秒）** → 越低越好。
+**测试环境：**在 Chromium 中运行仓库内的 Vitest 基准测试。实际结果可能受硬件影响。
+表中数值为**平均捕获耗时（毫秒）**，越低越好。
 
 ### 简单元素
 
-| 场景                 | SnapDOM 当前版本 | SnapDOM v1.9.9 | html2canvas | html-to-image |
+| 场景                 | SnapDOM 当前版 | SnapDOM v1.9.9 | html2canvas | html-to-image |
 | ------------------------ | --------------- | -------------- | ----------- | ------------- |
-| 小尺寸 (200×100)          | **0.5 ms**      | 0.8 ms         | 67.7 ms     | 3.1 ms        |
-| 模态框 (400×300)          | **0.5 ms**      | 0.8 ms         | 75.5 ms     | 3.6 ms        |
-| 页面视图 (1200×800)     | **0.5 ms**      | 0.8 ms         | 114.2 ms    | 3.3 ms        |
-| 大滚动 (2000×1500) | **0.5 ms**      | 0.8 ms         | 186.3 ms    | 3.2 ms        |
-| 超大尺寸 (4000×2000)   | **0.5 ms**      | 0.9 ms         | 425.9 ms    | 3.3 ms        |
+| 小尺寸（200×100）          | **0.5 ms**      | 0.8 ms         | 67.7 ms     | 3.1 ms        |
+| 模态框（400×300）          | **0.5 ms**      | 0.8 ms         | 75.5 ms     | 3.6 ms        |
+| 页面视图（1200×800）     | **0.5 ms**      | 0.8 ms         | 114.2 ms    | 3.3 ms        |
+| 大型滚动区域（2000×1500） | **0.5 ms**      | 0.8 ms         | 186.3 ms    | 3.2 ms        |
+| 超大尺寸（4000×2000）   | **0.5 ms**      | 0.9 ms         | 425.9 ms    | 3.3 ms        |
 
 
 ### 复杂元素
 
-| 场景                 | SnapDOM 当前版本 | SnapDOM v1.9.9 | html2canvas | html-to-image |
+| 场景                 | SnapDOM 当前版 | SnapDOM v1.9.9 | html2canvas | html-to-image |
 | ------------------------ | --------------- | -------------- | ----------- | ------------- |
-| 小尺寸 (200×100)          | **1.6 ms**      | 3.3 ms         | 68.0 ms     | 14.3 ms       |
-| 模态框 (400×300)          | **2.9 ms**      | 6.8 ms         | 87.5 ms     | 34.8 ms       |
-| 页面视图 (1200×800)     | **17.5 ms**     | 50.2 ms        | 178.0 ms    | 429.0 ms      |
-| 大滚动 (2000×1500) | **54.0 ms**     | 201.8 ms       | 735.2 ms    | 984.2 ms      |
-| 超大尺寸 (4000×2000)   | **171.4 ms**    | 453.7 ms       | 1,800.4 ms  | 2,611.9 ms    |
+| 小尺寸（200×100）          | **1.6 ms**      | 3.3 ms         | 68.0 ms     | 14.3 ms       |
+| 模态框（400×300）          | **2.9 ms**      | 6.8 ms         | 87.5 ms     | 34.8 ms       |
+| 页面视图（1200×800）     | **17.5 ms**     | 50.2 ms        | 178.0 ms    | 429.0 ms      |
+| 大型滚动区域（2000×1500） | **54.0 ms**     | 201.8 ms       | 735.2 ms    | 984.2 ms      |
+| 超大尺寸（4000×2000）   | **171.4 ms**    | 453.7 ms       | 1,800.4 ms  | 2,611.9 ms    |
 
 
 ### 运行基准测试
@@ -267,11 +265,11 @@ npm run test:benchmark
 ## 开发
 
 **源码结构：**
-- `src/api/` – 公共 API（`snapdom`、`preCache`）
-- `src/core/` – 捕获流程、克隆、准备、插件
-- `src/modules/` – 图片、字体、伪元素、背景、SVG
-- `src/exporters/` – toPng、toSvg、toBlob 等
-- `dist/` – 构建产物（`snapdom.js`、`snapdom.mjs`、`preCache.mjs`、`plugins.mjs`）
+- `src/api/` — 公开 API（`snapdom`、`preCache`）
+- `src/core/` — 捕获流程、克隆、预处理与插件
+- `src/modules/` — 图片、字体、伪元素、背景与 SVG
+- `src/exporters/` — `toPng`、`toSvg`、`toBlob` 等导出方法
+- `dist/` — 构建产物（`snapdom.js`、`snapdom.mjs`、`preCache.mjs`、`plugins.mjs`）
 
 **构建：**
 ```sh
@@ -284,7 +282,7 @@ npm run compile
 
 **测试：**
 ```sh
-npx playwright install   # 浏览器测试所需
+npx playwright install   # 浏览器测试需要
 npm test
 npm run test:benchmark
 ```
@@ -331,13 +329,13 @@ npm run test:benchmark
 
 特别感谢 [@megaphonecolin](https://github.com/megaphonecolin)、[@sdraper69](https://github.com/sdraper69)、[@reynaldichernando](https://github.com/reynaldichernando)、[@gamma-app](https://github.com/gamma-app)、[@jrjohnson](https://github.com/jrjohnson) 和 [@ryanander](https://github.com/ryanander) 对本项目的支持！
 
-如果您也想支持这个项目，您可以[成为赞助者](https://github.com/sponsors/tinchox5)。
+如果你也愿意支持这个项目，可以[成为赞助者](https://github.com/sponsors/tinchox5)。
 
 ## 支持我们
 
-如果 snapDOM 为您节省了时间，欢迎在 GitHub 上点一个 ⭐ —— 这能帮助其他开发者发现它，这就是我们唯一的请求。
+如果 snapDOM 帮你节省了时间，欢迎在 GitHub 上点一个 ⭐。这能让更多开发者发现它，也是我们唯一的请求。
 
-用 snapDOM 做了点东西？把徽章添加到您的 README 中：
+用 snapDOM 构建了项目？欢迎把这个徽章添加到你的 README：
 
 [![Built with snapDOM](https://img.shields.io/badge/built%20with-snapDOM-blue)](https://snapdom.dev)
 
@@ -347,22 +345,22 @@ npm run test:benchmark
 
 ### 使用 snapDOM 的项目
 
-snapDOM 已在 290+ 个公开仓库的生产环境中运行（[GitHub 依赖关系图](https://github.com/zumerlab/snapdom/network/dependents)）。以下是一些值得关注的项目，每一个都已通过其自身的 `package.json` 验证：
+snapDOM 已用于 290 多个公开仓库的生产环境（见 [GitHub 依赖关系图](https://github.com/zumerlab/snapdom/network/dependents)）。以下列出部分有代表性的项目，每个项目都已通过其自身的 `package.json` 核实：
 
-- [LobeHub](https://github.com/lobehub/lobehub) — 运营 AI 智能体的平台
+- [LobeHub](https://github.com/lobehub/lobehub) — AI 智能体平台
 - [Trilium Notes](https://github.com/TriliumNext/Trilium) — 层级式个人知识库
 - [Sealos](https://github.com/labring/sealos) — AI 原生云操作系统
 - [Tencent tmagic-editor](https://github.com/Tencent/tmagic-editor) — 低代码页面编辑器
-- [Playroom](https://github.com/seek-oss/playroom) — SEEK 出品的 JSX 设计工具
-- [GPT-Vis](https://github.com/antvis/GPT-Vis) — 蚂蚁集团 AntV 出品的 AI 友好数据可视化
+- [Playroom](https://github.com/seek-oss/playroom) — SEEK 推出的 JSX 设计工具
+- [GPT-Vis](https://github.com/antvis/GPT-Vis) — 蚂蚁集团 AntV 推出的、面向 AI 的数据可视化工具
 - [Rabby Wallet](https://github.com/RabbyHub/Rabby) — 面向 EVM 链的浏览器钱包
-- [uMap](https://github.com/umap-project/umap) — OpenStreetMap 地图构建工具
-- [ListenBrainz](https://github.com/metabrainz/listenbrainz-server) — MetaBrainz 出品的音乐追踪工具
-- [SnapDIFF](https://zumerlab.com/snapdiff/) — 浏览器内的视觉回归测试工具 *(Zumerlab 出品)*
+- [uMap](https://github.com/umap-project/umap) — OpenStreetMap 地图制作工具
+- [ListenBrainz](https://github.com/metabrainz/listenbrainz-server) — MetaBrainz 推出的音乐收听记录服务
+- [SnapDIFF](https://zumerlab.com/snapdiff/) — 浏览器内的视觉回归测试工具 *（由 Zumerlab 开发）*
 
-完整展示请见 **[snapdom.dev/made-with](https://snapdom.dev/made-with/)**。用了 snapDOM？欢迎[提交 PR](https://github.com/zumerlab/snapdom/pulls) 添加您的项目——仅限真实、可验证的项目。
+完整案例见 **[snapdom.dev/made-with](https://snapdom.dev/made-with/)**。如果你的项目也在使用 snapDOM，欢迎[提交 PR](https://github.com/zumerlab/snapdom/pulls) 添加到列表中 — 仅收录真实、可验证的项目。
 
-## Star 历史
+## Star 趋势
 
 [![Star History Chart](https://api.star-history.com/svg?repos=zumerlab/snapdom&type=Date)](https://www.star-history.com/#zumerlab/snapdom&Date)
 


### PR DESCRIPTION
## Summary

- technically review and rewrite `README_CN.md` and `FEATURES_CN.md` for natural Simplified Chinese used by front-end developers in China
- preserve API names, CSS properties, code examples, and internal method names such as `preCache`
- clarify terminology around DOM capture, cross-origin resources, rasterization, Firefox form-control rendering, caching, and plugins
- keep headings, tables, links, and code blocks structurally aligned with the English documentation

## Why

This responds to the request for a native-speaker technical review in [Discussion #450](https://github.com/zumerlab/snapdom/discussions/450), focusing on technical accuracy and readability rather than literal translation.

The translation was drafted with Codex + GPT-5.6 and manually reviewed and revised.

## Validation

- `git diff --check`
- verified matching heading, table-row, and fenced-code-block counts between the English and Chinese documents
- verified that non-comment code examples remain unchanged
- verified external URLs, internal anchors, and local file links
