### PR TITLE
fix(images): inline the capture root itself when it is an <img> or SVG <image> (#461)

### DIFF
--- a/__tests__/modules.images.test.js
+++ b/__tests__/modules.images.test.js
@@ -234,6 +234,30 @@ describe('inlineImages – extra coverage', () => {
     expect((div?.textContent || '')).toBe('img')
   })
 
+  it('inlines the capture root when it is itself an <img> (bare img capture)', async () => {
+    const img = document.createElement('img')
+    img.src = 'https://ex.com/bare-root.jpg'
+    wrap.appendChild(img)
+
+    vi.mocked(snapFetch).mockResolvedValueOnce({ ok: true, data: 'data:image/jpeg;base64,ROOT' })
+
+    // el propio <img> es la raíz de captura — sin wrapper
+    await inlineImages(img)
+
+    expect(img.src).toBe('data:image/jpeg;base64,ROOT')
+  })
+
+  it('inlines the capture root when it is itself an SVG <image>', async () => {
+    const image = document.createElementNS('http://www.w3.org/2000/svg', 'image')
+    image.setAttribute('href', 'https://ex.com/bare-root-svg.png')
+
+    vi.mocked(snapFetch).mockResolvedValueOnce({ ok: true, data: 'data:image/png;base64,SVGROOT' })
+
+    await inlineImages(image)
+
+    expect(image.getAttribute('href')).toBe('data:image/png;base64,SVGROOT')
+  })
+
   it('#341: inlines SVG <image href="https://..."> to data URL', async () => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     const img = document.createElementNS('http://www.w3.org/2000/svg', 'image')

--- a/src/modules/images.js
+++ b/src/modules/images.js
@@ -45,7 +45,10 @@ function extractImageDimensions(img) {
  * @returns {Promise<void>}
  */
 export async function inlineImages(clone, options = {}) {
+  // querySelectorAll only matches descendants: when the capture root is itself an
+  // <img>, it must be included or its src stays external and svg-as-image won't load it.
   const imgs = Array.from(clone.querySelectorAll('img'))
+  if (clone.tagName === 'IMG') imgs.unshift(clone)
   /** @param {HTMLImageElement} img */
   const processImg = async (img) => {
     // Normalize src/srcset/sizes to a single concrete URL
@@ -137,6 +140,7 @@ export async function inlineImages(clone, options = {}) {
 
   // #341: Inline SVG <image href="https://..."> (e.g. Highcharts, D3)
   const svgImages = Array.from(clone.querySelectorAll('image'))
+  if (clone.localName === 'image') svgImages.unshift(clone)
   const processSvgImage = async (el) => {
     const href = getSvgImageHref(el)
     if (!href || href.startsWith('data:') || href.startsWith('blob:')) return


### PR DESCRIPTION
Closes #461.

### Problem

`inlineImages` builds its worklist with a descendants-only query:

```js
const imgs = Array.from(clone.querySelectorAll('img'))
```

`querySelectorAll` never matches the element it is called on, so when the capture root **is** the `<img>`, it is skipped entirely. The exported SVG keeps an external `src="https://…"`, and SVG-as-image rasterization refuses external loads — the output is blank. The same image captured as a descendant works fine.

The identical pattern is used for SVG `<image>` (`clone.querySelectorAll('image')`), and it is affected the same way.

### Fix

Include the root in both worklists when it is itself an `<img>` / SVG `<image>`:

```js
const imgs = Array.from(clone.querySelectorAll('img'))
if (clone.tagName === 'IMG') imgs.unshift(clone)
```

This mirrors patterns already in the codebase — `inlineBackgroundImages` handles the root before walking children (`src/modules/background.js`), and `preCache` does exactly this for images:

```js
// src/api/preCache.js:58
if (root.tagName === 'IMG' && root.getAttribute('src')) imgEls.push(root)
```

`tagName` is used for the HTML `<img>` and `localName` for the SVG `<image>`, matching how the codebase distinguishes namespaces elsewhere (e.g. `localName` checks in `src/modules/CSSVar.js`). `unshift` keeps the root first so it lands in the first `BATCH`.

### Tests

Two regression tests in `__tests__/modules.images.test.js`, one for a root `<img>` and one for a root SVG `<image>`. Both fail on `main` and pass with the fix.

Full suite: **685 passed / 1 skipped**, against 683 / 1 on `main` — no regressions. `npm run lint` and `npm run test:types` clean. Verified on Chromium; I don't have the Firefox/WebKit Playwright binaries locally, though this change is DOM-level and not engine-specific.
