### PR TITLE
fix(clone): drop <picture> <source> elements so the inlined <img> src is not overridden (#462)

### DIFF
--- a/__tests__/core.clone.test.js
+++ b/__tests__/core.clone.test.js
@@ -109,6 +109,51 @@ describe('deepClone', () => {
   })
 })
 
+describe('deepClone — <picture> sources', () => {
+  const PX = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
+  function makePicture() {
+    const picture = document.createElement('picture')
+    picture.innerHTML =
+      '<source media="(min-width: 1367px)" srcset="https://example.com/big.jpg">' +
+      '<source media="(min-width: 0px)" srcset="https://example.com/small.jpg">'
+    const img = document.createElement('img')
+    img.src = PX
+    picture.appendChild(img)
+    document.body.appendChild(picture)
+    return picture
+  }
+
+  // A <source> out-ranks the <img>'s own src, so leaving it in the export re-selects an
+  // external URL that svg-as-image may not load — the picture then rasterizes blank even
+  // though the <img> was inlined correctly.
+  it('drops <source> children of <picture> so the inlined <img> src wins', async () => {
+    const picture = makePicture()
+    try {
+      const clone = await runClone(picture)
+      expect(clone.querySelectorAll('source').length).toBe(0)
+      const img = clone.querySelector('img')
+      expect(img).not.toBeNull()
+      expect(img.getAttribute('src')).toBe(PX)
+      expect(clone.outerHTML).not.toContain('example.com')
+    } finally {
+      picture.remove()
+    }
+  })
+
+  it('keeps <source> outside a <picture>', async () => {
+    const wrapper = document.createElement('div')
+    wrapper.innerHTML = '<source srcset="https://example.com/x.jpg">'
+    document.body.appendChild(wrapper)
+    try {
+      const clone = await runClone(wrapper)
+      expect(clone.querySelectorAll('source').length).toBe(1)
+    } finally {
+      wrapper.remove()
+    }
+  })
+})
+
 describe('deepClone edge cases', () => {
   it('clones unsupported node (Comment) as a new Comment', async () => {
     const fake = document.createComment('not supported')

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -186,6 +186,14 @@ export async function deepClone(node, sessionCache, options) {
       debugWarn(sessionCache, 'Nested <foreignObject> skipped (SVG spec limitation — not rendered by browsers)')
       return null
     }
+    // A <picture>'s <source> out-ranks its <img>'s own src, so it survives into the export
+    // still pointing at an external URL — and svg-as-image may not load external resources,
+    // so the picture rasterizes blank no matter how well the <img> was inlined. The <img>
+    // clone is already frozen to the variant the live page chose (freezeImgSrcset), so the
+    // sources carry nothing we still need: drop them and let that src win.
+    if (tag === 'source' && node.parentElement?.localName === 'picture') {
+      return null
+    }
   }
   if (node.nodeType === Node.TEXT_NODE) {
     return node.cloneNode(true)


### PR DESCRIPTION
Closes #462.

### Problem

A `<picture>`'s `<source>` elements out-rank the `<img>`'s own `src`. They were cloned verbatim, so inside the exported SVG the picture selection algorithm re-selected an **external URL** — and SVG-as-image cannot load external resources. The photo never painted, however correctly the `<img>` had been inlined.

The signature is a large SVG that rasterizes to a tiny PNG: everything embedded, nothing drawn.

### Why the existing machinery doesn't cover it

- `freezeImgSrcset` (`src/utils/clone.helpers.js`) already sets the cloned `<img>`'s `src = original.currentSrc` and strips `srcset`/`sizes` — but only on the `<img>`. The sibling `<source>` elements go through the generic child-clone path with their external `srcset`s intact.
- `pictureResolver` (`src/modules/pictureResolver.js`) only acts on a `<picture>` whose `<img src>` is a lazy-load **placeholder** (`isPlaceholderSrc`); it `continue`s for a normally-loaded picture, and runs against the live DOM before cloning.

So a fully-loaded `<picture>` reaches the SVG with its `<source>` list intact.

### Fix

Skip `<source>` children of a `<picture>` in `deepClone`:

```js
if (tag === 'source' && node.parentElement?.localName === 'picture') {
  return null
}
```

Because `freezeImgSrcset` has already frozen the clone to the variant the live page chose, the sources carry nothing still needed. **Art direction is preserved** — the chosen crop comes from `currentSrc`, not from re-evaluating the sources. Capturing the same carousel at a 1600px viewport embeds the 2200×1200 crops; at 500px it embeds the 600×1000 crops.

The check is deliberately narrow: `<source>` inside `<audio>`/`<video>` is untouched, and there's a test covering that.

### Results

Real WordPress hero carousel, real assets, identical 723 KB SVG both runs:

| | `<source>` in SVG | embedded images | PNG | photo painted |
|---|---|---|---|---|
| before | 4 | 229 KB + 280 KB | **48 KB** | **0 %** |
| after | 0 | 229 KB + 280 KB | **2046 KB** | **100 %** |

### Tests

New `deepClone — <picture> sources` block in `__tests__/core.clone.test.js`:
- `<source>` children of a `<picture>` are dropped and the inlined `<img>` src survives — fails on `main`, passes with the fix
- a `<source>` **outside** a `<picture>` is kept — guards against over-reach; passes either way by design

Full suite: **685 passed / 1 skipped**, against 683 / 1 on `main` — no regressions. `npm run lint` and `npm run test:types` clean. Verified on Chromium; I don't have the Firefox/WebKit Playwright binaries locally.
