### PR TITLE
fix(capture): keep the session nodeMap when same-origin iframes capture concurrently (#463)

### DIFF
--- a/__tests__/module.background.iframe-race.test.js
+++ b/__tests__/module.background.iframe-race.test.js
@@ -1,0 +1,113 @@
+/**
+ * Regression: CSS background-images were intermittently dropped when the captured tree
+ * contained same-origin iframes.
+ *
+ * Sibling iframes rasterize concurrently; each nested capture's applyCachePolicy reassigns
+ * the global cache.session.nodeMap, and the interleaved save/restore in rasterizeIframe
+ * could leave the global pointing at an orphaned nested map. inlineBackgroundImages then
+ * resolved clone→source through that empty map and skipped every background outside the
+ * iframes. Post-clone passes now receive the capture's own nodeMap reference (threaded
+ * from prepareClone through captureDOM), so the global's state no longer matters.
+ *
+ * Repro notes: backgrounds must come from a stylesheet rule with an http(s) URL — inline
+ * style attributes are copied by cloneNode and blob:/data: URLs are handled by other
+ * passes, both of which mask the bug. Asymmetric iframe content staggers the nested
+ * captures the way real pages do; with fast:false this failed 19/20 runs before the fix.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { snapdom } from '../src/api/snapdom.js'
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=='
+
+/** Find a same-origin http URL the vitest server serves with 200 (content type is
+ *  irrelevant — inlineSingleBackgroundEntry data-URLs any 200 response). */
+async function findFetchableUrl() {
+  const candidates = ['/README.md', '/package.json', '/index.html']
+  for (const c of candidates) {
+    try {
+      const r = await fetch(c)
+      if (r.ok) return new URL(c, location.origin).href
+    } catch { /* try next */ }
+  }
+  throw new Error('no fetchable same-origin URL found for the background fixture')
+}
+
+let mounted = []
+afterEach(() => {
+  mounted.forEach((el) => el.remove())
+  mounted = []
+})
+
+function makeContainer(bgUrl, iframeCount) {
+  const style = document.createElement('style')
+  style.textContent = `.snapbg-race { background-image: url("${bgUrl}"); background-size: cover; }`
+  document.head.appendChild(style)
+  mounted.push(style)
+
+  const container = document.createElement('div')
+  container.style.cssText = 'width:320px;padding:8px;background:#fff'
+  for (let i = 0; i < 3; i++) {
+    const d = document.createElement('div')
+    d.className = 'snapbg-race'
+    d.style.cssText = 'width:60px;height:40px;'
+    d.textContent = `bg${i}`
+    container.appendChild(d)
+  }
+  const frames = []
+  for (let i = 0; i < iframeCount; i++) {
+    const f = document.createElement('iframe')
+    f.style.cssText = 'width:80px;height:50px;border:0'
+    container.appendChild(f)
+    const sp = document.createElement('div')
+    sp.textContent = 'x'.repeat(50)
+    container.appendChild(sp)
+    frames.push(f)
+  }
+  document.body.appendChild(container)
+  mounted.push(container)
+  frames.forEach((f, i) => {
+    const doc = f.contentDocument
+    doc.open()
+    if (i === 0) {
+      // heavy iframe: many nodes + an image decode, so its nested capture overlaps the others
+      let inner = `<img src="${TINY_PNG}" style="width:20px;height:20px" alt="">`
+      for (let k = 0; k < 120; k++) inner += `<span style="color:rgb(${k},0,0)">s${k}</span>`
+      doc.write(`<html><body style="margin:0">${inner}</body></html>`)
+    } else {
+      doc.write(
+        `<html><body style="margin:0"><div style="width:100%;height:100%;background:teal">f${i}</div></body></html>`
+      )
+    }
+    doc.close()
+  })
+  return container
+}
+
+/** count of nodes in the output SVG whose inline style has a data: background-image */
+function countInlinedBackgrounds(dataUrl) {
+  const svgText = decodeURIComponent(dataUrl.split(',').slice(1).join(','))
+  const doc = new DOMParser().parseFromString(svgText, 'image/svg+xml')
+  let count = 0
+  for (const el of doc.querySelectorAll('[style]')) {
+    const s = el.getAttribute('style') || ''
+    if (/background-image:\s*url\(["']?data:/.test(s)) count++
+  }
+  return count
+}
+
+describe('background-image inlining races with same-origin iframe rasterization', () => {
+  for (const fast of [true, false]) {
+    it(`fast:${fast} — backgrounds survive 3 concurrent same-origin iframes (6 runs)`, async () => {
+      const bgUrl = await findFetchableUrl()
+      for (let run = 0; run < 6; run++) {
+        const container = makeContainer(bgUrl, 3)
+        const res = await snapdom(container, { fast })
+        const inlined = countInlinedBackgrounds(res.url)
+        mounted.forEach((el) => el.remove())
+        mounted = []
+        expect(inlined, `fast:${fast} run ${run}`).toBe(3)
+      }
+    }, 60000)
+  }
+})

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -100,7 +100,7 @@ export async function captureDOM(element, options) {
   const preClipRect = options.clip ? resolveClipRect(element, options.clip) : null
   let state = { element, options, plugins: options.plugins }
 
-  let clone, classCSS, styleCache, clipWindow
+  let clone, classCSS, styleCache, nodeMap, clipWindow
   let fontsCSS = ''
   let baseCSS = ''
   let dataURL
@@ -120,7 +120,10 @@ export async function captureDOM(element, options) {
   await runHook('beforeClone', state)
   const undoClamp = lineClampTree(state.element, preClipRect)
   try {
-    ({ clone, classCSS, styleCache, clipWindow } = await prepareClone(state.element, state.options))
+    // Keep this capture's own clone→source map: nested iframe captures reassign
+    // cache.session.nodeMap concurrently (see rasterizeIframe), so the global cannot be
+    // trusted after the clone phase — every later pass must use this reference.
+    ({ clone, classCSS, styleCache, nodeMap, clipWindow } = await prepareClone(state.element, state.options))
 
     // state = {clone, classCSS, styleCache, ...state}
 
@@ -133,14 +136,14 @@ export async function captureDOM(element, options) {
     // #426: zero margins that collapse through the root edge so the clone's
     // content sits flush like the captured border box (no clipping / no offset).
     if (clone) {
-      neutralizeRootMarginCollapse(state.element, clone, cache.session.nodeMap)
+      neutralizeRootMarginCollapse(state.element, clone, nodeMap)
     }
   } finally {
     undoClamp()
   }
 
   // AFTERCLONE
-  state = { clone, classCSS, styleCache, ...state }
+  state = { clone, classCSS, styleCache, nodeMap, ...state }
   await runHook('afterClone', state)
   if (undoPictureResolver) await undoPictureResolver()
   sanitizeCloneForXHTML(state.clone)
@@ -153,7 +156,7 @@ export async function captureDOM(element, options) {
     }
   }
   try {
-    await ligatureIconToImage(state.clone, state.element)
+    await ligatureIconToImage(state.clone, state.element, state.nodeMap)
   } catch { /* non-blocking */ }
 
   // Asset phases are network/decode-bound and independent: images ∥ backgrounds ∥ fonts run
@@ -166,18 +169,18 @@ export async function captureDOM(element, options) {
   const assetsPhase = (async () => {
     await Promise.all([
       runIdle(() => inlineImages(state.clone, state.options)),
-      runIdle(() => inlineBackgroundImages(state.element, state.clone, state.styleCache, state.options)),
+      runIdle(() => inlineBackgroundImages(state.element, state.clone, state.styleCache, state.options, state.nodeMap)),
     ])
     // backdrop-filter can't be trusted to the svg rasterizer (#457): pre-compose it
     // from the already-inlined clone. Non-blocking — a failure just loses the effect.
     try {
-      emulateBackdropFilters(state.element, state.clone)
+      emulateBackdropFilters(state.element, state.clone, state.nodeMap)
     } catch (e) {
       console.warn('[snapdom] backdrop-filter emulation failed:', e)
     }
     // Perceptual image downsampling (on by default via `compress`). No-op when off.
     if (options.compress) {
-      await runIdle(() => compressCloneAssets(state.clone, state.options))
+      await runIdle(() => compressCloneAssets(state.clone, state.options, state.nodeMap))
     }
   })()
 
@@ -310,7 +313,7 @@ export async function captureDOM(element, options) {
         try {
           const cssAll = (state.scrollbarCSS || '') + state.baseCSS + state.fontsCSS +
             'svg{overflow:visible;} foreignObject{overflow:visible;}' + state.classCSS
-          reconcileCloneLayout(state.element, state.clone, cssAll, cache.session.nodeMap, w0, h0)
+          reconcileCloneLayout(state.element, state.clone, cssAll, state.nodeMap, w0, h0)
         } catch (e) {
           console.warn('[snapdom] reconcile pass failed:', e)
         }

--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -20,7 +20,7 @@ import { resolveClipRect, freezeViewportPositioned } from '../utils/capture.help
  * @param {Object} [options={}] - Capture options
  * @param {string[]} [options.exclude] - CSS selectors for elements to exclude
  * @param {Function} [options.filter] - Custom filter function
- * @returns {Promise<Object>} Object containing the clone, generated CSS, and style cache
+ * @returns {Promise<Object>} Object containing the clone, generated CSS, style cache, and the session clone→source nodeMap
  */
 
 export async function prepareClone(element, options = {}) {
@@ -216,7 +216,7 @@ export async function prepareClone(element, options = {}) {
       cloneNode.style.marginBlockStart = '0'
     }
   }
-  return { clone, classCSS, styleCache: sessionCache.styleCache, clipWindow }
+  return { clone, classCSS, styleCache: sessionCache.styleCache, nodeMap: sessionCache.nodeMap, clipWindow }
 }
 
 // helpers (stabilizeLayout, resolveBlobUrlsInTree) ahora vienen de utils; bloque antiguo eliminado.

--- a/src/modules/backdropFilter.js
+++ b/src/modules/backdropFilter.js
@@ -21,9 +21,10 @@ import { getStyle } from '../utils'
 /**
  * @param {Element} root - Original capture root (for viewport rects)
  * @param {Element} clone - Prepared clone (styles and resources already inlined)
+ * @param {Map<Node, Node>} [nodeMap] - Session clone→source map; pass the capture's own
+ *   reference — the global fallback can be stale after nested iframe captures.
  */
-export function emulateBackdropFilters(root, clone) {
-  const nodeMap = cache.session.nodeMap
+export function emulateBackdropFilters(root, clone, nodeMap = cache.session.nodeMap) {
   const targets = []
   const walker = document.createTreeWalker(clone, NodeFilter.SHOW_ELEMENT)
   for (let n = walker.currentNode; n; n = walker.nextNode()) {

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -154,11 +154,13 @@ async function inlineBackgroundForNode(srcNode, cloneNode, styleCache, options) 
  * @param {HTMLElement} clone The cloned element receiving inline styles.
  * @param {WeakMap} styleCache
  * @param {Object} [options={}]
+ * @param {Map<Node, Node>} [nodeMap] Session clone→source map. Must be the capturing
+ *   session's own reference: the global cache.session.nodeMap (fallback) is reassigned by
+ *   concurrent nested iframe captures and may be an orphaned map by the time this pass runs.
  * @returns {Promise<void>}
  */
-export async function inlineBackgroundImages(source, clone, styleCache, options = {}) {
+export async function inlineBackgroundImages(source, clone, styleCache, options = {}, nodeMap = cache.session.nodeMap) {
   if (!clone) return
-  const nodeMap = cache.session.nodeMap
 
   const jobs = []
   if (source && needsBackgroundInline(source)) jobs.push([source, clone])

--- a/src/modules/compress.js
+++ b/src/modules/compress.js
@@ -165,12 +165,12 @@ function originalBox(el) {
  *
  * @param {Element} clone
  * @param {object} options
+ * @param {Map<Node, Node>} [nodeMap] - Session clone→source map (falls back to the global)
  * @returns {Promise<{count:number}>}
  */
-export async function compressClonedBackgrounds(clone, options) {
+export async function compressClonedBackgrounds(clone, options, nodeMap = cache.session.nodeMap) {
   if (!options.compress) return { count: 0 }
   const eff = (options.scale || 1) * (options.dpr || 1)
-  const nodeMap = cache.session.nodeMap
   const els = []
   // include the root clone itself, then descendants
   const candidates = [clone, ...clone.querySelectorAll('*')]
@@ -249,11 +249,13 @@ export async function compressClonedSvgImages(clone, options) {
  * Run all compression passes over the clone (no-op when `compress` is off).
  * @param {Element} clone
  * @param {object} options
+ * @param {Map<Node, Node>} [nodeMap] - Session clone→source map; pass the capture's own
+ *   reference — the global fallback can be stale after nested iframe captures.
  * @returns {Promise<void>}
  */
-export async function compressCloneAssets(clone, options) {
+export async function compressCloneAssets(clone, options, nodeMap) {
   if (!options.compress) return
   await compressClonedImages(clone, options)
-  await compressClonedBackgrounds(clone, options)
+  await compressClonedBackgrounds(clone, options, nodeMap)
   await compressClonedSvgImages(clone, options)
 }

--- a/src/modules/iconFonts.js
+++ b/src/modules/iconFonts.js
@@ -235,7 +235,7 @@ export async function materialIconToImage(
  * Replace Material ligature nodes in the CLONE by <img>.
  * Reads styles from SOURCE for accurate size/color/variation/class.
  */
-export async function ligatureIconToImage(cloneRoot, sourceRoot) {
+export async function ligatureIconToImage(cloneRoot, sourceRoot, nodeMap = cache.session.nodeMap) {
   if (!(cloneRoot instanceof Element)) return 0
 
   const selector = '.material-icons, [class*="material-symbols"]'
@@ -249,7 +249,6 @@ export async function ligatureIconToImage(cloneRoot, sourceRoot) {
   // Map each clone node to its exact source via the clone→source nodeMap built by deepClone.
   // Pairing the two trees positionally breaks when excludeMode:'remove' drops nodes from the
   // clone but not the source: indices shift and we read the wrong source's color/size/variation.
-  const nodeMap = cache.session.nodeMap
   const sourceNodes = (sourceRoot instanceof Element)
     ? Array.from(sourceRoot.querySelectorAll(selector)).filter(n => n && n.textContent && n.textContent.trim())
     : []

--- a/src/utils/clone.helpers.js
+++ b/src/utils/clone.helpers.js
@@ -452,11 +452,13 @@ export async function rasterizeIframe(iframe, sessionCache, options) {
   // Pin viewport so body background fills exactly content box (fixes 400x110 → 400x150)
   const unpin = pinIframeViewport(doc, contentWidth, contentHeight)
   // The nested capture below runs its own captureDOM → applyCachePolicy, which REASSIGNS
-  // cache.session.{nodeMap,styleMap,styleCache} to fresh instances. That orphans every entry
-  // the parent capture cloned before reaching this iframe, so the parent's later
-  // inlineBackgroundImages/pseudo recursion (which resolve clone→source via cache.session.nodeMap)
-  // skip those subtrees — e.g. a remote background/mask on a sibling of the iframe is silently
-  // dropped. Snapshot and restore the parent session around the nested call so it stays intact.
+  // cache.session.{nodeMap,styleMap,styleCache} to fresh instances. Sibling iframes rasterize
+  // concurrently, so these save/restore pairs can interleave and the global session may point
+  // at an orphaned nested map afterwards — that's why every post-clone pass of a capture
+  // (inlineBackgroundImages, backdrop-filter, compress, icon fonts, layout reconcile) receives
+  // the capture's own nodeMap reference instead of trusting the global. The snapshot/restore
+  // here is kept as best-effort hygiene so the global usually ends up back at the parent's
+  // session, but nothing may rely on it mid-capture.
   const parentNodeMap = cache.session.nodeMap
   const parentStyleMap = cache.session.styleMap
   const parentStyleCache = cache.session.styleCache


### PR DESCRIPTION
Closes #463.

> This is the largest of the three fixes I'm opening, and it changes a call-site convention. Happy to reshape it if you'd prefer a different approach — see the alternative at the bottom.

### Problem

`inlineBackgroundImages` resolves clone→source exclusively through the module-global `cache.session.nodeMap`. That global is reassigned mid-capture by nested iframe captures:

1. Child subtrees deep-clone **concurrently** (`Promise.all` in `idleCallback`, `src/utils/clone.helpers.js`).
2. A same-origin `<iframe>` triggers `rasterizeIframe` → a **nested `snapdom` capture**.
3. Each capture's `applyCachePolicy()` reassigns `cache.session.nodeMap = new Map()` under the default `'soft'` policy.
4. `rasterizeIframe` snapshots/restores the parent map around the nested call — but with siblings cloning in parallel those save/restore pairs **interleave**, so one iframe can restore a map another had already replaced.
5. The background pass then reads an empty map, every lookup misses, and every `background-image` outside the iframes is dropped.

`<img>` inlining is unaffected because it walks the clone via `querySelectorAll`, not `nodeMap`.

This is adjacent to #439 / #440, which moved this pass onto the `nodeMap` for child alignment. That fix is correct — the issue here is that the *global* it reads can be a different map by the time the pass runs.

### Fix

Thread the capture's **own** `nodeMap` reference through, instead of re-reading the global after the clone phase:

- `prepareClone` returns `sessionCache.nodeMap`
- `captureDOM` keeps it on `state` and passes it to every post-clone consumer: `neutralizeRootMarginCollapse`, `ligatureIconToImage`, `inlineBackgroundImages`, `emulateBackdropFilters`, `compressCloneAssets`, `reconcileCloneLayout`

Each module function takes `nodeMap` as a **trailing optional parameter defaulting to `cache.session.nodeMap` at call time**, so every existing caller (preCache, plugins, unit tests) is unaffected and no public signature breaks.

The `rasterizeIframe` save/restore is kept as best-effort hygiene for the global, with its comment updated to state that nothing may rely on it mid-capture.

### Tests

`__tests__/module.background.iframe-race.test.js` — 3 stylesheet-URL backgrounds alongside 3 asymmetric same-origin iframes, under both `fast: true` and `fast: false`, 6 runs each.

Without the fix it reports **0 inlined backgrounds instead of 3**, failing on the first run in both modes. With the fix I ran it 5 consecutive times (60 captures) with no flakes.

Two notes for anyone reproducing it, since both mask the bug:
- backgrounds must come from a **stylesheet rule** with an `http(s)` URL — inline `style` attributes are copied by `cloneNode`, and `blob:`/`data:` URLs are handled by other passes
- iframe content must be **asymmetric**, so nested captures overlap as they do on real pages

Full suite: **685 passed / 1 skipped**, against 683 / 1 on `main` — no regressions. `npm run lint` and `npm run test:types` clean. Verified on Chromium; I don't have the Firefox/WebKit Playwright binaries locally.

### Alternative, if you'd prefer a smaller diff

The narrow version is to make `applyCachePolicy` not reassign `nodeMap` when a capture is already in flight (a depth counter or a capture-scoped session object). That touches one file instead of seven, but leaves the global as shared mutable state that any future concurrent path can trip over again. I went with threading the reference because it removes the class of bug rather than the instance — but I'm happy to switch.
