### PR TITLE
fix(styles): keep the height of wrappers whose children are all out of flow (#467)

### DIFF
--- a/__tests__/module.styles.abspos-wrapper.test.js
+++ b/__tests__/module.styles.abspos-wrapper.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { snapdom } from '../src/index'
+import { inlineAllStyles } from '../src/modules/styles.js'
+
+/**
+ * A wrapper sized only by the viewport (height:100vh) whose children are all
+ * absolutely positioned had its height/block-size stripped as a "transparent flow wrapper".
+ * The site stylesheet is gone inside the foreignObject, so nothing restored that height and
+ * the wrapper collapsed to 0: every following section shifted up and painted over it.
+ */
+
+function freshSession() {
+  return { styleMap: new Map(), styleCache: new WeakMap(), nodeMap: new Map() }
+}
+
+/** Size declaration snapdom emits for `el` in the exported SVG, or '' when absent. */
+function sizeRuleFor(svg, selector) {
+  // result.url is a data: URL — drop everything before the markup itself.
+  const markup = svg.slice(svg.indexOf('<'))
+  const doc = new DOMParser().parseFromString(markup, 'image/svg+xml')
+  const el = doc.querySelector(`foreignObject ${selector}`)
+  if (!el) return null
+  const css = [...doc.querySelectorAll('style')].map((s) => s.textContent).join('\n')
+  const classes = (el.getAttribute('class') || '').split(/\s+/).filter((c) => /^c\d+$/.test(c))
+  for (const c of classes) {
+    const rule = css.match(new RegExp(`\\.${c}\\s*\\{([^}]*)\\}`))
+    if (!rule) continue
+    const size = rule[1].match(/(?:^|;)\s*(?:block-size|height)\s*:\s*([^;]+)/)
+    if (size) return size[1].trim()
+  }
+  return ''
+}
+
+describe('stripHeightForWrappers — wrappers whose children are all out of flow', () => {
+  let root, sheet
+  afterEach(() => { root?.remove(); sheet?.remove() })
+
+  function mount(css, html) {
+    sheet = document.createElement('style')
+    sheet.textContent = css
+    document.head.appendChild(sheet)
+    root = document.createElement('div')
+    root.innerHTML = html
+    document.body.appendChild(root)
+    return root
+  }
+
+  it('keeps the height of a wrapper whose only children are absolutely positioned', async () => {
+    // Height must come from a stylesheet: an inline height is already respected (guard 1).
+    mount(
+      '.sd-hero{position:relative;height:300px}' +
+      '.sd-hero > .sd-slide{position:absolute;top:0;left:0;right:0;bottom:0}',
+      '<div class="sd-hero"><div class="sd-slide">caption text</div></div>' +
+      '<div class="sd-after">below the hero</div>',
+    )
+
+    const hero = root.querySelector('.sd-hero')
+    expect(getComputedStyle(hero).height).toBe('300px')
+    // The trap: textContent and scrollHeight both look like real in-flow content.
+    expect(/\S/.test(hero.textContent)).toBe(true)
+    expect(hero.scrollHeight).toBe(300)
+
+    const svg = decodeURIComponent((await snapdom(root)).url)
+    expect(sizeRuleFor(svg, '.sd-hero')).toBe('300px')
+  })
+
+  it('records the size on the clone style key rather than dropping it', async () => {
+    mount(
+      '.sd-hero2{position:relative;height:250px}' +
+      '.sd-hero2 > .sd-slide{position:absolute;inset:0}',
+      '<div class="sd-hero2"><div class="sd-slide">caption</div></div>',
+    )
+    const hero = root.querySelector('.sd-hero2')
+    const clone = hero.cloneNode(true)
+    const session = freshSession()
+
+    await inlineAllStyles(hero, clone, session)
+
+    expect(session.styleMap.get(clone)).toMatch(/(?:^|;)\s*(?:block-size|height)\s*:\s*250px/)
+  })
+
+  it('still strips the height of a genuinely transparent flow wrapper', async () => {
+    // Negative control: in-flow child of the same height — the wrapper is redundant and
+    // removing its height lets the clone reflow naturally, which is the point of the pass.
+    mount(
+      '.sd-wrap{position:relative;height:300px}' +
+      '.sd-wrap > .sd-inner{height:300px}',
+      '<div class="sd-wrap"><div class="sd-inner">in flow</div></div>',
+    )
+    const svg = decodeURIComponent((await snapdom(root)).url)
+    expect(sizeRuleFor(svg, '.sd-wrap')).toBe('')
+  })
+
+  it('treats a wrapper holding only display:none children as having no flow content', async () => {
+    mount(
+      '.sd-hidden-host{position:relative;height:120px}' +
+      '.sd-hidden-host > .sd-gone{display:none}',
+      '<div class="sd-hidden-host"><div class="sd-gone">hidden</div></div>',
+    )
+    const svg = decodeURIComponent((await snapdom(root)).url)
+    expect(sizeRuleFor(svg, '.sd-hidden-host')).toBe('120px')
+  })
+})

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -415,24 +415,35 @@ function isFlexOrGridItem(el) {
 
 /**
  * ¿Hay contenido en flujo? Versión rápida:
- *  - Texto no vacío → true (no dispara layout).
+ *  - Nodo de texto directo no vacío → true (no dispara layout).
  *  - <br> inmediato → true.
- *  - Geometry probe: scrollHeight > padding (abspos NO suma) → true.
+ *  - Algún hijo elemento en flujo → true.
+ *
+ * Both questions are about THIS element's own flow, so neither `textContent` nor a
+ * scrollHeight probe can answer them: `textContent` also sees text inside absolutely
+ * positioned descendants, and scrollHeight is floored at clientHeight, so a wrapper whose
+ * children are all out of flow still reports its own used height. Trusting either one made
+ * stripHeightForWrappers drop the height of such a wrapper, which then collapsed to 0 inside
+ * the foreignObject — every following section shifted up over it.
  * @param {Element} el
- * @param {CSSStyleDeclaration} cs  // ya lo tenemos en mano
  */
-function hasFlowFast(el, cs) {
-  if (el.textContent && /\S/.test(el.textContent)) return true
+function hasFlowFast(el) {
+  // Only direct text nodes belong to this element's flow.
+  for (let n = el.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === 3 && /\S/.test(n.nodeValue)) return true
+  }
   const f = el.firstElementChild, l = el.lastElementChild
   if ((f && f.tagName === 'BR') || (l && l.tagName === 'BR')) return true
 
-  // Probe geométrico (1 lectura de layout): evita recorrer hijos
-  // Nota: scrollHeight no incluye hijos absolute; si sólo hay absolute → ≈ padding
-  const sh = el.scrollHeight
-  if (sh === 0) return false
-  const pt = parseFloat(cs.paddingTop) || 0
-  const pb = parseFloat(cs.paddingBottom) || 0
-  return sh > pt + pb
+  // An element child contributes flow content only when it is itself in flow. getStyle
+  // memoizes per node, and this runs only after the cheap text/<br> paths miss.
+  for (let c = el.firstElementChild; c; c = c.nextElementSibling) {
+    const s = getStyle(c)
+    if (s.display === 'none') continue
+    const pos = s.position
+    if (pos !== 'absolute' && pos !== 'fixed') return true
+  }
+  return false
 }
 
 /**
@@ -484,7 +495,7 @@ function stripHeightForWrappers(el, cs, snap) {
   if (cs.visibility === 'hidden' || cs.opacity === '0') return
 
   // 6) Solo wrappers "en flujo" realmente neutros
-  if (!hasFlowFast(el, cs)) return
+  if (!hasFlowFast(el)) return
 
   // 7) Ahora sí: quitamos height y block-size del snapshot
   delete snap.height


### PR DESCRIPTION
Closes #467.

### Problem

`stripHeightForWrappers` drops `height`/`block-size` from the style snapshot of a "transparent flow wrapper", relying on `hasFlowFast` to prove the element has in-flow content that will re-establish the box in the clone. Inside the `foreignObject` the authored stylesheet is gone, so when that assumption is wrong nothing restores the height and the wrapper collapses to 0 — every following section shifts up and paints over it.

Both of `hasFlowFast`'s signals answer a different question than the one being asked:

- **`el.textContent`** also sees text inside absolutely positioned descendants, so a wrapper holding only an abspos overlay with a caption reads as having in-flow text.
- **`scrollHeight > paddingTop + paddingBottom`** is unreliable because `scrollHeight` is floored at `clientHeight`. A non-scrolling block always reports at least its own used height, whatever its children are. The old comment said abspos children don't contribute — true of the *content* height, but the probe never drops to the padding it's compared against.

For a `height:300px` hero whose children are all `position:absolute`, `textContent` is non-blank **and** `scrollHeight` is 300. Both signals say "has flow content", so the height is stripped.

### Fix

`hasFlowFast` now asks the real question — does *this element* have in-flow content?

- direct non-blank **text nodes** (not `textContent`, which reaches into out-of-flow descendants)
- an immediate `<br>` (unchanged)
- an **element child that is itself in flow** — skipping `display:none`, `absolute` and `fixed`

The children walk runs only after the cheap text/`<br>` paths miss, and `getStyle` memoizes per node (`cache.computedStyle`), so children whose styles are needed later aren't recomputed. `cs` is no longer used and is dropped from the signature; the single caller is updated.

The direct-text-node loop uses the same `nodeType === 3 && /\S/.test(...)` idiom already present in this file at `styles.js:222`.

### Behaviour change, scoped

The new check returns `false` in exactly the intended case (all children out of flow or `display:none`). It returns `true` in one case the old probe returned `false`: an in-flow child when `scrollHeight === 0`. That can't cause a regression — `scrollHeight` is floored at `clientHeight`, so `scrollHeight === 0` only when the element's own used height is already 0, making the strip a no-op. Guard 2b (`|usedH - scrollHeight| > TOL`) covers every other path.

### Tests

`__tests__/module.styles.abspos-wrapper.test.js`, 4 cases:

1. abspos-only wrapper keeps its height **end to end** (asserted on the size rule in the exported SVG)
2. same, asserted via the clone style key through `inlineAllStyles`
3. **negative control** — a genuinely transparent wrapper still gets its height stripped, so the pass keeps doing its job
4. a `display:none`-only wrapper is treated as having no flow content

3 of the 4 fail on `main`; the negative control passes both ways by design.

Note for reviewers: the wrapper height must come from a **stylesheet**. An inline `style="height:…"` is already respected by guard 1 and masks the bug.

Full suite: **693 passed / 1 skipped**, against 689 / 1 on `main` — no regressions. `npm run lint` and `npm run test:types` clean. Verified on Chromium; I don't have the Firefox/WebKit Playwright binaries locally.
