### PR TITLE
fix(css): emit the base reset for tags evicted from the defaultStyle cache (#468)

### DIFF
--- a/__tests__/utils.css.base-reset-eviction.test.js
+++ b/__tests__/utils.css.base-reset-eviction.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { snapdom } from '../src/index'
+import { cache } from '../src/core/cache.js'
+import { generateDedupedBaseCSS, getDefaultStyleForTag } from '../src/utils/css.js'
+
+/**
+ * The per-tag base reset neutralizes UA defaults inside the foreignObject. It was built by
+ * reading cache.defaultStyle — an EvictingMap — directly, so a document using more distinct
+ * tags than MAX_DEFAULT_STYLE had its earliest-registered tags evicted before the reset was
+ * generated. Those tags got no reset rule and the UA stylesheet applied instead, reflowing
+ * the capture taller than the source.
+ */
+
+/** Tag names appearing in the selector of every non-class rule of the generated CSS. */
+function resetTags(css) {
+  const tags = new Set()
+  for (const m of css.matchAll(/(?:^|\})\s*([a-z0-9][a-z0-9, ]*?)\s*\{/gi)) {
+    for (const t of m[1].split(',')) tags.add(t.trim())
+  }
+  return tags
+}
+
+function svgCss(url) {
+  const markup = decodeURIComponent(url)
+  const doc = new DOMParser().parseFromString(markup.slice(markup.indexOf('<')), 'image/svg+xml')
+  return [...doc.querySelectorAll('style')].map((s) => s.textContent).join('\n')
+}
+
+// Comfortably more distinct tags than MAX_DEFAULT_STYLE (30). These must each carry *distinct*
+// UA styling: tags that compute identically (aside/section/nav/header/… are all plain blocks)
+// collide on the style-key memo, never call getDefaultStyleForTag, and so never occupy a slot.
+const MANY_TAGS = [
+  'h1', 'h2', 'h4', 'h5', 'h6', 'p', 'pre', 'code', 'em', 'strong', 'small', 'sub', 'sup',
+  'mark', 'del', 'ins', 'a', 'hr', 'blockquote', 'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  'table', 'thead', 'tbody', 'tr', 'td', 'th', 'form', 'label', 'input', 'button', 'select',
+  'textarea', 'fieldset', 'legend', 'img', 'span', 'b', 'i', 'q', 'cite', 'abbr',
+]
+
+describe('generateDedupedBaseCSS — tags evicted from the defaultStyle cache', () => {
+  let root, sheet
+  afterEach(() => { root?.remove(); sheet?.remove() })
+
+  it('emits a base reset for an early tag even when the document exceeds the cache cap', async () => {
+    sheet = document.createElement('style')
+    // Reset the heading margin to the CSS initial value, so the property is diffed away and
+    // the element depends entirely on the base reset to neutralize the UA default.
+    sheet.textContent = '#sd-cap h3{margin:0;font-size:16px;font-weight:400}'
+    document.head.appendChild(sheet)
+
+    root = document.createElement('div')
+    root.id = 'sd-cap'
+    // h3 first, so it is among the earliest tags registered and thus the first evicted.
+    // Each filler needs real content: an empty, zero-sized element can be culled before the
+    // style pass and would then never consume a defaultStyle slot.
+    root.innerHTML = '<h3>Heading</h3>' + MANY_TAGS.map((t) => `<${t}>x</${t}>`).join('')
+    document.body.appendChild(root)
+
+    const distinct = new Set([...root.querySelectorAll('*')].map((e) => e.tagName.toLowerCase()))
+    expect(distinct.size).toBeGreaterThan(30)
+
+    // Start cold, as on a real page load: h3 is registered first and then evicted by the
+    // tags that follow it. A cache warmed by earlier tests would already hold h3 and hide it.
+    cache.defaultStyle.clear()
+
+    const css = svgCss((await snapdom(root)).url)
+    expect(resetTags(css)).toContain('h3')
+  })
+
+  it('covers every used tag that has defaults, not just the ones still cached', async () => {
+    const used = ['h1', 'h2', 'h3', 'p', 'hr', 'strong', 'main', ...MANY_TAGS]
+    // Simulate the end-of-capture state: the cache has been churned past its cap.
+    cache.defaultStyle.clear()
+    const css = generateDedupedBaseCSS([...used].sort())
+    const emitted = resetTags(css)
+    const expected = used.filter((t) => Object.keys(getDefaultStyleForTag(t)).length > 0)
+    for (const tag of expected) expect(emitted).toContain(tag)
+  })
+})

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -277,7 +277,15 @@ export function generateDedupedBaseCSS(usedTagNames) {
   const groups = new Map()
 
   for (let tagName of usedTagNames) {
-    const styles = cache.defaultStyle.get(tagName)
+    // Resolve through getDefaultStyleForTag instead of reading cache.defaultStyle directly.
+    // That cache is an EvictingMap (MAX_DEFAULT_STYLE), and this runs at the very end of a
+    // capture: a document using more distinct tags than the cap has already had its earliest
+    // tags evicted. Reading the map raw returned undefined for exactly those tags and the
+    // `continue` silently emitted no base reset for them, so inside the foreignObject the UA
+    // stylesheet's defaults applied instead (h1..h3/p margins, hr borders, list padding…) and
+    // the capture reflowed taller than the source. Re-deriving is memoized and idempotent;
+    // NO_DEFAULTS_TAGS still yields {} and is dropped by the empty-key guard below.
+    const styles = getDefaultStyleForTag(tagName)
     if (!styles) continue
 
     // Creamos la "firma" del bloque CSS para comparar


### PR DESCRIPTION
Closes #468.

### Problem

`generateDedupedBaseCSS` built the per-tag base reset by reading the cache directly:

```js
const styles = cache.defaultStyle.get(tagName)
if (!styles) continue
```

`cache.defaultStyle` is an `EvictingMap` capped at `MAX_DEFAULT_STYLE = 30`, evicting FIFO. The reset is generated at the **very end** of a capture, so any document using more than 30 distinct tags has already evicted its earliest-registered tags. The lookup returns `undefined` and `continue` silently emits no reset rule for exactly those tags.

The base reset is what neutralizes the UA stylesheet inside the `foreignObject`. Properties the page reset to the CSS initial value get diffed out of the element's generated class precisely *because* the base reset is expected to cover them — so when it's missing there is nothing left to hold the UA default off: `h1..h3`/`p` margins, `hr` borders, list padding all come back, and the capture reflows taller than the source.

Which tags are hit depends on registration order, so the corruption is silent and varies per page. Observed on a real site: 39 distinct tags, and the tags at first-appearance ranks 15–23 (`picture`, `main`, `h1`, `h2`, `h3`, `strong`, `p`, `hr`) all lost their reset while `h4` at rank 25 survived. Four `<h3>`s regained the UA `1em` margin, growing the article by 121px and pushing a button 171px down over the section below it.

### Fix

Resolve through `getDefaultStyleForTag(tagName)` instead of reading the map raw. It's memoized, idempotent, and re-derives an evicted entry on demand. `NO_DEFAULTS_TAGS` still yields `{}` and is dropped by the existing empty-key guard, so SVG/head tags are unaffected.

One line, plus a comment recording why the raw map read is wrong here.

### Cost

Each evicted tag now re-derives once at end of capture — a sandbox element plus a computed-style read. It's a single bounded pass (each tag is visited once, so ~9 derivations on the 39-tag page above), negligible against a full capture.

Raising `MAX_DEFAULT_STYLE` would also make this particular page work, but it only moves the cap rather than removing the failure mode — the next document with more tags hits it again. Happy to go that route instead if you'd prefer.

### Tests

`__tests__/utils.css.base-reset-eviction.test.js`, 2 cases:

1. **end to end** — a capture using >30 distinct tags still emits a base reset for an early-registered `h3`
2. **unit invariant** — every used tag that has defaults appears in the output, even starting from a cleared cache

Both fail on `main`.

Note for reviewers: the fillers in the end-to-end test must have *distinct* UA styling. Tags that compute identically (`aside`/`section`/`nav`/`header`/…) collide on the style-key memo in `styles.js`, never call `getDefaultStyleForTag`, and so never occupy a cache slot — with those the capture registers only 28 tags, stays under the cap, and the bug doesn't trigger.

Full suite: **691 passed / 1 skipped**, against 689 / 1 on `main` — no regressions. `npm run lint` and `npm run test:types` clean. Verified on Chromium; I don't have the Firefox/WebKit Playwright binaries locally.
