### PR TITLE
fix: parse final font-face declarations without semicolons

### DIFF
--- a/__tests__/module.fonts.test.js
+++ b/__tests__/module.fonts.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { iconToImage, embedCustomFonts } from '../src/modules/fonts.js'
 import { cache } from '../src/core/cache.js'
+import { snapFetch } from '../src/modules/snapFetch.js'
+
+vi.mock('../src/modules/snapFetch.js', () => ({
+  snapFetch: vi.fn(),
+}))
 
 // === helpers locales ===
 function cleanFontEnvironment() {
@@ -15,6 +20,15 @@ function addStyleTag(css) {
   style.textContent = css
   document.head.appendChild(style)
   return style
+}
+
+function addFontStylesheet(href = 'https://cdn.example.com/fonts.css') {
+  const link = document.createElement('link')
+  link.setAttribute('data-test-font', 'true')
+  link.rel = 'stylesheet'
+  link.href = href
+  document.head.appendChild(link)
+  return link
 }
 
 // Helpers nuevos para la API smart
@@ -189,6 +203,66 @@ describe('embedCustomFonts', () => {
     expect(css).toMatch(/src:\s*local\(['"]MyFont['"]\),\s*local\(['"]FallbackFont['"]\)/)
     expect(css).toMatch(/font-style:\s*italic/)
     document.head.removeChild(style)
+  })
+
+  it.each([
+    {
+      property: 'font-family',
+      css: '@font-face{src:local("Nunito");font-style:normal;font-weight:100 300;font-stretch:100%;font-family:Nunito}',
+      expected: /font-family:\s*Nunito/,
+    },
+    {
+      property: 'font-weight',
+      css: '@font-face{font-family:Nunito;src:url(https://cdn.example.com/Nunito-Light.ttf);font-weight:100 300}',
+      expected: /font-weight:\s*100 300/,
+      fontUrl: 'https://cdn.example.com/Nunito-Light.ttf',
+    },
+    {
+      property: 'font-style',
+      css: '@font-face{font-family:Nunito;src:local("Nunito");font-weight:100 300;font-stretch:100%;font-style:italic}',
+      expected: /font-style:\s*italic/,
+      required: makeRequired('Nunito', '200', 'italic', 100),
+    },
+    {
+      property: 'font-stretch',
+      css: '@font-face{font-family:Nunito;src:local("Nunito");font-style:normal;font-weight:100 300;font-stretch:75%}',
+      expected: /font-stretch:\s*75%/,
+      required: makeRequired('Nunito', '200', 'normal', 75),
+    },
+    {
+      property: 'unicode-range',
+      css: '@font-face{font-family:Nunito;src:local("Nunito");font-style:normal;font-weight:100 300;font-stretch:100%;unicode-range:U+0000-00FF}',
+      expected: /unicode-range:\s*U\+0000-00FF/,
+    },
+  ])('parses $property when the final declaration has no semicolon', async ({ css: fontCss, expected, required, fontUrl }) => {
+    const href = 'https://cdn.example.com/fonts.css'
+    addFontStylesheet(href)
+    vi.mocked(snapFetch).mockResolvedValueOnce({
+      ok: true,
+      data: fontCss,
+      status: 200,
+      url: href,
+      fromCache: false,
+    })
+    if (fontUrl) {
+      vi.mocked(snapFetch).mockResolvedValueOnce({
+        ok: true,
+        data: 'data:font/ttf;base64,AA==',
+        status: 200,
+        url: fontUrl,
+        fromCache: false,
+        mime: 'font/ttf',
+      })
+    }
+
+    const css = await embedCustomFonts({
+      required: required || makeRequired('Nunito', '200', 'normal', 100),
+      usedCodepoints: makeUsedCodepoints('A'),
+      fontStylesheetDomains: ['cdn.example.com'],
+    })
+
+    expect(css).toMatch(expected)
+    if (fontUrl) expect(css).toContain('data:font/ttf;base64,AA==')
   })
 })
 

--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -335,6 +335,11 @@ async function inlineImportsAndRewrite(cssText, ownerHref, useProxy) {
 const URL_RE = /url\((["']?)([^"')]+)\1\)/g
 const FACE_RE = /@font-face[^{}]*\{[^}]*\}/g
 
+function getFontFaceDeclaration(block, property, fallback = '') {
+  const match = block.match(new RegExp(`${property}\\s*:\\s*([^;}]+)[;}]`, 'i'))
+  return (match?.[1] || fallback).trim()
+}
+
 /** @param {string} ur */
 function parseUnicodeRange(ur) {
   if (!ur) return []
@@ -470,13 +475,13 @@ function dedupeFontFaces(cssText) {
   const out = []
 
   for (const block of cssText.match(FACE_RE_G) || []) {
-    const familyRaw = block.match(/font-family:\s*([^;]+);/i)?.[1] || ''
+    const familyRaw = getFontFaceDeclaration(block, 'font-family')
     const family = pickPrimaryFamily(familyRaw)
-    const weightSpec = (block.match(/font-weight:\s*([^;]+);/i)?.[1] || '400').trim()
-    const styleSpec = (block.match(/font-style:\s*([^;]+);/i)?.[1] || 'normal').trim()
-    const stretchSpec = (block.match(/font-stretch:\s*([^;]+);/i)?.[1] || '100%').trim()
-    const urange = (block.match(/unicode-range:\s*([^;]+);/i)?.[1] || '').trim()
-    const srcRaw = (block.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || '').trim()
+    const weightSpec = getFontFaceDeclaration(block, 'font-weight', '400')
+    const styleSpec = getFontFaceDeclaration(block, 'font-style', 'normal')
+    const stretchSpec = getFontFaceDeclaration(block, 'font-stretch', '100%')
+    const urange = getFontFaceDeclaration(block, 'unicode-range')
+    const srcRaw = getFontFaceDeclaration(block, 'src')
 
     const urls = extractSrcUrls(srcRaw, location.href)
     const srcPart = urls.length
@@ -821,15 +826,15 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
 
       let facesOut = ''
       for (const face of cssText.match(FACE_RE) || []) {
-        const famRaw = (face.match(/font-family:\s*([^;]+);/i)?.[1] || '').trim()
+        const famRaw = getFontFaceDeclaration(face, 'font-family')
         const family = pickPrimaryFamily(famRaw)
         if (!family || isIconFont(family)) continue
 
-        const weightSpec = (face.match(/font-weight:\s*([^;]+);/i)?.[1] || '400').trim()
-        const styleSpec = (face.match(/font-style:\s*([^;]+);/i)?.[1] || 'normal').trim()
-        const stretchSpec = (face.match(/font-stretch:\s*([^;]+);/i)?.[1] || '100%').trim()
-        const urange = (face.match(/unicode-range:\s*([^;]+);/i)?.[1] || '').trim()
-        const srcRaw = (face.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || '').trim()
+        const weightSpec = getFontFaceDeclaration(face, 'font-weight', '400')
+        const styleSpec = getFontFaceDeclaration(face, 'font-style', 'normal')
+        const stretchSpec = getFontFaceDeclaration(face, 'font-stretch', '100%')
+        const urange = getFontFaceDeclaration(face, 'unicode-range')
+        const srcRaw = getFontFaceDeclaration(face, 'src')
         const srcUrls = extractSrcUrls(srcRaw, link.href)
 
         if (!faceMatchesRequired(family, styleSpec, weightSpec, stretchSpec)) continue


### PR DESCRIPTION
## Summary
- parse all relevant `@font-face` declarations when the final declaration ends at `}` without a semicolon
- share declaration extraction between font-face deduplication and external stylesheet processing
- cover `font-family`, `font-weight`, `font-style`, `font-stretch`, and `unicode-range`

## Testing
- `npx vitest run __tests__/module.fonts.test.js __tests__/module.fonts.more.test.js __tests__/module.fonts.more.more.test.js __tests__/module.fonts.katex.test.js __tests__/module.fonts.iframe.test.js --browser.headless --reporter=verbose`
- `npx eslint src/modules/fonts.js __tests__/module.fonts.test.js`
- `npm run test:types`
- `npm run compile`