### PR TITLE
fix: entry keyframe animations blank out the captured element

### DIFF
--- a/__tests__/core.capture.animation.test.js
+++ b/__tests__/core.capture.animation.test.js
@@ -1,0 +1,35 @@
+// An entry animation whose 0% keyframe hides the element (opacity:0 / transform)
+// must not blank it out in the capture: the clone must render the element's
+// CURRENT (post-animation) frame, not replay the animation from 0%.
+import { describe, it, expect, afterEach } from 'vitest'
+import { snapdom } from '../src/index'
+
+const added = []
+function mount(el) { document.body.appendChild(el); added.push(el); return el }
+afterEach(() => { while (added.length) added.pop().remove(); window.scrollTo(0, 0) })
+
+describe('entry keyframe animations do not blank the captured element', () => {
+  it('a fixed element that finished a fade-in (opacity 0→1) is captured opaque', async () => {
+    const style = mount(document.createElement('style'))
+    style.textContent =
+      '@keyframes snapFadeIn { from { opacity: 0; transform: scale(0.9) translateY(10px); } to { opacity: 1; transform: none; } }'
+    const box = mount(document.createElement('div'))
+    box.style.cssText =
+      'position:fixed;left:20px;top:20px;width:60px;height:60px;background:rgb(0, 0, 255);z-index:9999;margin:0;animation:snapFadeIn 60ms ease both;'
+
+    // Let the entry animation finish so the LIVE element is fully opaque.
+    await Promise.all(box.getAnimations().map((a) => a.finished))
+    expect(getComputedStyle(box).opacity).toBe('1')
+
+    const canvas = await snapdom.toCanvas(document.body, { clip: 'viewport', dpr: 1 })
+    const ctx = canvas.getContext('2d')
+    const sx = canvas.width / window.innerWidth
+    const sy = canvas.height / window.innerHeight
+    const px = ctx.getImageData(Math.round(50 * sx), Math.round(50 * sy), 1, 1).data
+
+    // Without the fix the clone replays snapFadeIn from 0% (opacity:0) → transparent → blank.
+    expect(px[2]).toBeGreaterThan(200) // blue channel present
+    expect(px[0]).toBeLessThan(60)
+    expect(px[3]).toBeGreaterThan(200) // fully opaque, not the 0% frame
+  })
+})

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -337,6 +337,19 @@ export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
     normalizeInlineStyleToComputed(source, clone, pre)
   }
 
+  // A static snapshot must not animate. snapdom embeds the document's `@keyframes` and applies
+  // each element's computed `animation` (via its generated style class); when the SVG snapshot
+  // is rasterized the animation replays from its 0% keyframe. An entry animation whose start
+  // frame hides the element (e.g. `from { opacity: 0 }`, or an off-screen `transform`) therefore
+  // blanks it out even though the live element already finished animating. Pin `animation` off
+  // with inline `!important` on the elements that actually have one (inline beats the generated
+  // class regardless of specificity); the current opacity/transform captured in the snapshot
+  // below then renders as the frozen, already-settled frame.
+  const animName = pre.getPropertyValue('animation-name')
+  if (clone && clone.style && animName && animName !== 'none') {
+    clone.style.setProperty('animation', 'none', 'important')
+  }
+
   const snap = getSnapshot(source, pre, ctx.options)
 
   const flexItem = isFlexOrGridItem(source)


### PR DESCRIPTION
## Summary

An element that plays a CSS **entry animation** whose starting keyframe hides it — e.g. `from { opacity: 0 }` or a large off-screen `transform` — is captured **blank / mispositioned**, even though the live element has already finished animating and is fully visible on screen.

This is very common with modal/popover/toast UIs (Radix, shadcn/ui, Tailwind's `animate-in`, etc.), where the open animation typically starts from `opacity: 0` and a small scale/translate.

## Root cause

snapdom embeds the document's `@keyframes` into the serialized SVG and re-applies each element's computed `animation` (through its generated style class). When that SVG is rasterized as an `<img>`, the CSS animation **replays from its `0%` keyframe** — an SVG-as-image is a single static frame taken at load time, so the animation never advances past its start.

So for an entry animation like:

```css
@keyframes modalIn {
  from { opacity: 0; transform: scale(0.95) translateY(10px); }
  to   { opacity: 1; transform: scale(1) translateY(0); }
}
.modal { animation: modalIn 0.15s ease; }
```

the captured element renders at `opacity: 0` (invisible) / scaled-and-shifted, regardless of the element's real, settled state.

I verified the serialized SVG indeed contains both the `@keyframes` block and the element's `animation:` declaration, and that the rasterized frame is the `0%` one.

## Fix

For elements that actually have an animation (`animation-name !== none`), pin `animation: none !important` on the clone.

- Inline `!important` beats the generated style class regardless of specificity, so the animation is reliably disabled.
- The element's **current** `opacity`/`transform` is already captured in the style snapshot, so it renders as the frozen, already-settled frame (what the user actually sees).
- The `animation-name` guard leaves non-animated elements untouched (no extra inline props, no output bloat), and also skips detached nodes whose computed `animation-name` is empty.

Transitions are intentionally left alone: a static snapshot never triggers a state change, so transitions don't replay and don't cause this problem.

```js
const animName = pre.getPropertyValue('animation-name')
if (clone && clone.style && animName && animName !== 'none') {
  clone.style.setProperty('animation', 'none', 'important')
}
```

## Reproduction

```html
<!doctype html>
<style>
  @keyframes fadeIn { from { opacity: 0; transform: scale(0.9) } to { opacity: 1; transform: none } }
  .box {
    position: fixed; left: 20px; top: 20px; width: 60px; height: 60px;
    background: blue; animation: fadeIn 150ms ease both;
  }
</style>
<div class="box">hi</div>
<script type="module">
  import { snapdom } from '@zumer/snapdom';
  const box = document.querySelector('.box');
  await Promise.all(box.getAnimations().map(a => a.finished)); // element is fully visible now
  const canvas = await snapdom.toCanvas(document.body, { clip: 'viewport' });
  document.body.appendChild(canvas); // before this fix: the blue box is missing (opacity 0)
</script>
```

**Before:** the blue box is absent from the capture (rendered at the `0%` keyframe, `opacity: 0`).
**After:** the blue box is captured opaque, at its settled position.

## Test

Adds `__tests__/core.capture.animation.test.js`: fades a fixed element in (`opacity 0 → 1`), waits for the animation to finish, captures with `clip: 'viewport'`, and asserts the pixel at the element's position is opaque blue. It fails on `main` (`expected 0 to be greater than 200` — fully transparent) and passes with this fix.

Full browser suite (capture / clip / clone / prepare / toCanvas / background / pseudo / snapdom) stays green.
