### PR TITLE
perf: stylesheet-aware snapshot (PERF-5) + cache/bloom/bg reuse

### DIFF
--- a/__tests__/guards.walkFusion.test.js
+++ b/__tests__/guards.walkFusion.test.js
@@ -1,0 +1,160 @@
+// Guard tests for the capture hot-path optimizations (walk-fusion / recomputation removal).
+//
+// Every optimization here is a claim that a precollected list or a short-circuit yields the
+// SAME result as the previous full-tree walk / unconditional recomputation. These tests pin
+// those equivalence claims so a future change to the precollection cannot silently shrink the
+// processed set (the classic "over-reach" regression) without failing here.
+//
+// Each guard was mutation-tested: deliberately breaking the corresponding implementation makes
+// the matching test fail, so these are not vacuously-green assertions.
+//
+// Runs in real Chromium (vitest browser).
+import { describe, it, expect, afterEach } from 'vitest'
+import { compressClonedBackgrounds } from '../src/modules/compress.js'
+import { forceContentVisibility } from '../src/utils/prepare.helpers.js'
+
+let mounted = []
+
+afterEach(() => {
+  for (const el of mounted) el.remove?.()
+  mounted = []
+})
+
+function mount(el) {
+  document.body.appendChild(el)
+  mounted.push(el)
+  return el
+}
+
+// ---------------------------------------------------------------------------------------------
+// compressClonedBackgrounds: when the precollected bgClones list is present it must yield the
+// SAME element set as the querySelectorAll('*') fallback. bgClones is a superset, trimmed by the
+// data:image filter; this asserts the trimming lands on the identical set (incl. the root).
+// ---------------------------------------------------------------------------------------------
+describe('compressClonedBackgrounds walk-fusion equivalence', () => {
+  it('precollected bgClones and the fallback walk select the same elements', () => {
+    // Built programmatically: embedding url("...") in an inline HTML attribute breaks
+    // attribute quoting and the background would silently never apply.
+    const DATA = 'url("data:image/png;base64,AAAADATA")'
+    const root = document.createElement('div')
+    const mk = (id, bg) => {
+      const el = document.createElement('div')
+      if (id) el.id = id
+      if (bg) el.style.backgroundImage = bg
+      return el
+    }
+    root.append(
+      mk('bg', DATA),
+      mk('plain', ''),
+      mk('bg-deep', DATA),
+      mk('bg-nondata', 'url(https://example.test/a.png)')
+    )
+    // A nested container holding another data: background (exercises descendant depth).
+    const nested = mk('nested', '')
+    nested.append(mk('bg-nested', DATA))
+    root.append(nested)
+    mount(root)
+
+    // What the OLD full walk selected: root + descendants whose inline bg contains data:image.
+    const byWalk = [root, ...root.querySelectorAll('*')].filter(
+      (el) => el.style && el.style.backgroundImage && el.style.backgroundImage.includes('data:image')
+    )
+
+    // What the NEW precollected path selects: a superset (bgClones) trimmed by the same filter.
+    const bgClones = [root, ...root.querySelectorAll('*')]
+    const byPrecollected = bgClones.filter(
+      (el) => el.style && el.style.backgroundImage && el.style.backgroundImage.includes('data:image')
+    )
+
+    expect(byPrecollected.map((e) => e.id || 'root')).toEqual(byWalk.map((e) => e.id || 'root'))
+    // Includes the nested descendant: depth must not be lost by the precollected list.
+    expect(byWalk.map((e) => e.id).sort()).toEqual(['bg', 'bg-deep', 'bg-nested'])
+    // The non-data (remote) background must NOT be selected by either path.
+    expect(byWalk.some((e) => e.id === 'bg-nondata')).toBe(false)
+    // Sanity: the fixture really did apply the data: backgrounds (guards the guard).
+    expect(byWalk.length).toBeGreaterThan(0)
+  })
+
+  it('falls back to the walk when no precollected list exists', async () => {
+    const root = document.createElement('div')
+    root.style.backgroundImage = 'url("data:image/png;base64,AAAADATA")'
+    root.style.width = '10px'
+    root.style.height = '10px'
+    mount(root)
+
+    // No _snapdomCollect -> must take the querySelectorAll fallback without throwing.
+    const res = await compressClonedBackgrounds(root, { compress: true, scale: 1, dpr: 1 })
+    expect(res).toHaveProperty('count')
+    expect(typeof res.count).toBe('number')
+  })
+
+  it('does nothing when compress is disabled', async () => {
+    const root = document.createElement('div')
+    root._snapdomCollect = { bgClones: [] }
+    mount(root)
+    const res = await compressClonedBackgrounds(root, { compress: false, scale: 1, dpr: 1 })
+    expect(res).toEqual({ count: 0 })
+  })
+})
+
+// ---------------------------------------------------------------------------------------------
+// forceContentVisibility: the short-circuit skips getComputedStyle when an inline
+// content-visibility exists, but MUST still force stylesheet-driven `auto`. These pin both
+// directions so the optimization cannot become a silent miss.
+// ---------------------------------------------------------------------------------------------
+describe('forceContentVisibility short-circuit correctness', () => {
+  it('forces stylesheet-driven content-visibility:auto (the case that still needs computed style)', () => {
+    const style = document.createElement('style')
+    style.textContent = '.cv-auto { content-visibility: auto; }'
+    mount(style)
+
+    const el = document.createElement('div')
+    el.className = 'cv-auto'
+    mount(el)
+
+    // No inline declaration -> implementation must read computed style and force it.
+    expect(el.style.contentVisibility).toBe('')
+    const undo = forceContentVisibility(el)
+    expect(el.style.contentVisibility).toBe('visible')
+
+    undo()
+    expect(el.style.contentVisibility).toBe('')
+  })
+
+  it('forces an inline auto and leaves non-auto elements untouched', () => {
+    const auto = document.createElement('div')
+    auto.style.contentVisibility = 'auto'
+    const visible = document.createElement('div')
+    visible.style.contentVisibility = 'visible'
+    const host = document.createElement('div')
+    host.append(auto, visible)
+    mount(host)
+
+    const undo = forceContentVisibility(host)
+    expect(auto.style.contentVisibility).toBe('visible')
+    expect(visible.style.contentVisibility).toBe('visible')
+
+    undo()
+    expect(auto.style.contentVisibility).toBe('auto')
+    expect(visible.style.contentVisibility).toBe('visible')
+  })
+
+  it('restores the original value on undo for descendants', () => {
+    const host = document.createElement('div')
+    const kid = document.createElement('div')
+    kid.style.contentVisibility = 'auto'
+    const other = document.createElement('div')
+    other.style.contentVisibility = 'hidden'
+    host.append(kid, other)
+    mount(host)
+
+    const undo = forceContentVisibility(host)
+    expect(kid.style.contentVisibility).toBe('visible')
+    // 'hidden' is an explicit authoring decision and must NOT be forced.
+    expect(other.style.contentVisibility).toBe('hidden')
+
+    undo()
+    expect(kid.style.contentVisibility).toBe('auto')
+    expect(other.style.contentVisibility).toBe('hidden')
+  })
+})

--- a/__tests__/module.CSSVar.test.js
+++ b/__tests__/module.CSSVar.test.js
@@ -85,4 +85,50 @@ describe('resolveCSSVars', () => {
     expect(clone.style.color).toBe('rgb(255, 0, 0)')
     style.remove()
   })
+
+  it('still materializes snapshot-less KEY_PROPS (stop-color) without any author var()', async () => {
+    // <stop> is NO_DEFAULTS_TAGS (no style snapshot) and the SVG paint pass does not copy
+    // stop-color, so the baseline comparison must stay thorough for it even on var-free pages.
+    const { seedUsedProps } = await import('../src/modules/styles.js')
+    const style = document.createElement('style')
+    style.textContent = '.cssvar-stop { stop-color: rgb(255, 0, 0); }'
+    document.head.appendChild(style)
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const stop = document.createElementNS('http://www.w3.org/2000/svg', 'stop')
+    stop.setAttribute('class', 'cssvar-stop')
+    svg.appendChild(stop)
+    host.appendChild(svg)
+    try {
+      seedUsedProps(host)
+      expect(getComputedStyle(stop).stopColor).toBe('rgb(255, 0, 0)')
+      const clone = document.createElementNS('http://www.w3.org/2000/svg', 'stop')
+      resolveCSSVars(stop, clone)
+      expect(clone.style.stopColor).toBe('rgb(255, 0, 0)')
+    } finally {
+      style.remove()
+      svg.remove()
+    }
+  })
+
+  it('skips the baseline comparison for snapshot-covered elements when no author var() exists', async () => {
+    // No var() in any scanned stylesheet: color rides the style snapshot instead of being
+    // redundantly re-resolved per node (1 getComputedStyle + 5 getPropertyValue saved).
+    const { seedUsedProps } = await import('../src/modules/styles.js')
+    const style = document.createElement('style')
+    style.textContent = '.cssvar-plain { color: rgb(0, 0, 255); }'
+    document.head.appendChild(style)
+    const src = document.createElement('div')
+    src.className = 'cssvar-plain'
+    host.appendChild(src)
+    try {
+      seedUsedProps(host)
+      expect(getComputedStyle(src).color).toBe('rgb(0, 0, 255)')
+      const clone = document.createElement('div')
+      resolveCSSVars(src, clone)
+      expect(clone.style.color).toBe('')
+    } finally {
+      style.remove()
+      src.remove()
+    }
+  })
 })

--- a/__tests__/module.styles.juan-regressions.test.js
+++ b/__tests__/module.styles.juan-regressions.test.js
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function freshSession() {
+  return { styleMap: new Map(), styleCache: new WeakMap(), nodeMap: new Map() }
+}
+
+async function freshStylesModule() {
+  vi.resetModules()
+  return import('../src/modules/styles.js')
+}
+
+async function styleKeyFor(inlineAllStyles, source) {
+  const clone = source.cloneNode(true)
+  const session = freshSession()
+  await inlineAllStyles(source, clone, session)
+  return session.styleMap.get(clone) || ''
+}
+
+function propertyFromKey(key, property) {
+  const match = key.match(new RegExp(`(?:^|;)${property}:([^;]+)`))
+  return match ? match[1] : null
+}
+
+describe('stylesheet scan fidelity regressions', () => {
+  const mounted = []
+
+  afterEach(() => {
+    for (const node of mounted) node.remove()
+    mounted.length = 0
+    delete window.__SNAPDOM_FULL_PROPS
+    vi.restoreAllMocks()
+  })
+
+  function mount(css, html) {
+    const sheet = document.createElement('style')
+    sheet.textContent = css
+    document.head.appendChild(sheet)
+    const root = document.createElement('div')
+    root.innerHTML = html
+    document.body.appendChild(root)
+    mounted.push(root, sheet)
+    return root
+  }
+
+  it('falls back to the full computed-style read when any stylesheet is CSSOM-inaccessible', async () => {
+    const root = mount(
+      '.jr-cross{letter-spacing:7px;text-transform:uppercase;font-style:italic;text-indent:11px}',
+      '<p class="jr-cross">cross origin styles</p>',
+    )
+    const source = root.firstElementChild
+    expect(getComputedStyle(source).letterSpacing).toBe('7px')
+
+    const deniedSheet = {}
+    Object.defineProperty(deniedSheet, 'cssRules', {
+      get() { throw new DOMException('Cannot access rules', 'SecurityError') },
+    })
+    vi.spyOn(Document.prototype, 'styleSheets', 'get').mockReturnValue([deniedSheet])
+
+    const { inlineAllStyles, notifyStyleEpoch } = await freshStylesModule()
+    const restrictedKey = await styleKeyFor(inlineAllStyles, source)
+
+    window.__SNAPDOM_FULL_PROPS = true
+    notifyStyleEpoch()
+    const fullKey = await styleKeyFor(inlineAllStyles, source)
+
+    for (const property of ['letter-spacing', 'text-transform', 'font-style', 'text-indent']) {
+      expect(fullKey, `full read control contains ${property}`).toMatch(new RegExp(`(?:^|;)${property}:`))
+      expect(restrictedKey, `CSSOM denial preserves ${property}`).toMatch(new RegExp(`(?:^|;)${property}:`))
+    }
+  })
+
+  it('preserves UA styles that differ from CSS initial values without author CSS', async () => {
+    const root = mount(
+      '',
+      '<pre>a  b\n c</pre><em>emphasis</em>' +
+      '<table><tbody><tr><th>heading</th></tr></tbody></table>' +
+      '<ol><li>numbered</li></ol>',
+    )
+    const { inlineAllStyles } = await freshStylesModule()
+    const pre = root.querySelector('pre')
+    const em = root.querySelector('em')
+    const th = root.querySelector('th')
+    const ol = root.querySelector('ol')
+
+    expect(getComputedStyle(pre).whiteSpace).toBe('pre')
+    expect(getComputedStyle(em).fontStyle).toBe('italic')
+    expect(parseInt(getComputedStyle(th).fontWeight, 10)).toBeGreaterThanOrEqual(700)
+    expect(getComputedStyle(ol).listStyleType).toBe('decimal')
+
+    const preKey = await styleKeyFor(inlineAllStyles, pre)
+    const preservesPreWhitespace = /(?:^|;)white-space:pre(?:;|$)/.test(preKey) ||
+      (/(?:^|;)white-space-collapse:preserve(?:;|$)/.test(preKey) &&
+       /(?:^|;)text-wrap-mode:nowrap(?:;|$)/.test(preKey))
+    expect(preservesPreWhitespace, `UA <pre> whitespace survives in ${preKey}`).toBe(true)
+    expect(await styleKeyFor(inlineAllStyles, em)).toMatch(/(?:^|;)font-style:italic(?:;|$)/)
+    expect(await styleKeyFor(inlineAllStyles, th)).toMatch(/(?:^|;)font-weight:(?:bold|700)(?:;|$)/)
+    expect(await styleKeyFor(inlineAllStyles, ol)).toMatch(/(?:^|;)list-style-type:decimal(?:;|$)/)
+  })
+
+  it('does not share snapshots between siblings selected by position', async () => {
+    const root = mount(
+      '.jr-pos>li:nth-child(even){color:rgb(255,0,0);letter-spacing:5px}',
+      '<ul class="jr-pos"><li>odd</li><li>even</li></ul>',
+    )
+    const [odd, even] = root.querySelectorAll('li')
+    const { inlineAllStyles } = await freshStylesModule()
+
+    expect(getComputedStyle(odd).color).not.toBe(getComputedStyle(even).color)
+    const oddKey = await styleKeyFor(inlineAllStyles, odd)
+    const evenKey = await styleKeyFor(inlineAllStyles, even)
+
+    expect(evenKey).not.toBe(oddKey)
+    expect(evenKey).toMatch(/(?:^|;)letter-spacing:5px(?:;|$)/)
+  })
+
+  it('does not share used geometry between same-class siblings with different content', async () => {
+    const root = mount(
+      '.jr-card{width:100px;background:#eee;font:16px/20px Arial}',
+      '<div class="jr-cards"><div class="jr-card">one</div>' +
+      '<div class="jr-card">one<br>two<br>three</div></div>',
+    )
+    const [shortCard, tallCard] = root.querySelectorAll('.jr-card')
+    const { inlineAllStyles } = await freshStylesModule()
+    const shortHeight = getComputedStyle(shortCard).height
+    const tallHeight = getComputedStyle(tallCard).height
+
+    expect(parseFloat(tallHeight)).toBeGreaterThan(parseFloat(shortHeight))
+    const shortKey = await styleKeyFor(inlineAllStyles, shortCard)
+    const tallKey = await styleKeyFor(inlineAllStyles, tallCard)
+
+    expect(propertyFromKey(shortKey, 'height')).toBe(shortHeight)
+    expect(propertyFromKey(tallKey, 'height')).toBe(tallHeight)
+    expect(tallKey).not.toBe(shortKey)
+  })
+})

--- a/__tests__/module.styles.residual.test.js
+++ b/__tests__/module.styles.residual.test.js
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function freshSession() {
+  return { styleMap: new Map(), styleCache: new WeakMap(), nodeMap: new Map() }
+}
+async function freshStylesModule() {
+  vi.resetModules()
+  return import('../src/modules/styles.js')
+}
+async function styleKeyFor(inlineAllStyles, source) {
+  const clone = source.cloneNode(true)
+  const session = freshSession()
+  await inlineAllStyles(source, clone, session)
+  return session.styleMap.get(clone) || ''
+}
+
+describe('residual fidelity: nested shadows and CSSOM', () => {
+  const mounted = []
+  afterEach(() => {
+    for (const n of mounted) n.remove()
+    mounted.length = 0
+    delete window.__SNAPDOM_FULL_PROPS
+    vi.restoreAllMocks()
+  })
+  function mount(css, html) {
+    const sheet = document.createElement('style')
+    sheet.textContent = css
+    document.head.appendChild(sheet)
+    const root = document.createElement('div')
+    root.innerHTML = html
+    document.body.appendChild(root)
+    mounted.push(root, sheet)
+    return root
+  }
+
+  it('sees styles from nested open shadow roots', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    mounted.push(host)
+    const outer = host.attachShadow({ mode: 'open' })
+    const innerHost = document.createElement('div')
+    innerHost.id = 'innerHost'
+    outer.appendChild(innerHost)
+    const inner = innerHost.attachShadow({ mode: 'open' })
+    const style = document.createElement('style')
+    style.textContent = '#deep{letter-spacing:9px}'
+    inner.appendChild(style)
+    const deep = document.createElement('span')
+    deep.id = 'deep'
+    deep.textContent = 'hi'
+    inner.appendChild(deep)
+    // Ensure computed reflects
+    expect(getComputedStyle(deep).letterSpacing).toBe('9px')
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    // seed from the deep element's root (its doc is same, but host chain includes nested)
+    // seedUsedProps should walk nested shadows when scanning doc, but we also need to ensure
+    // inlineAllStyles for deep sees the style
+    // Use the deep element as source; its ownerDocument is top doc, and nested shadow styles are in that doc's tree
+    // We call seedUsedProps on the host to prime doc state
+    seedUsedProps(host)
+    const key = await styleKeyFor(inlineAllStyles, deep)
+    expect(key).toMatch(/letter-spacing:9px/)
+  })
+
+  it('picks up insertRule without DOM mutation', async () => {
+    const root = mount('', '<div class="jr-insert">x</div>')
+    const el = root.querySelector('.jr-insert')
+    const sheet = document.createElement('style')
+    sheet.textContent = '.jr-insert{color:rgb(10,10,10)}'
+    document.head.appendChild(sheet)
+    mounted.push(sheet)
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    seedUsedProps(root)
+    const before = await styleKeyFor(inlineAllStyles, el)
+    expect(before).toMatch(/color:/)
+    // Insert new rule with previously unused property
+    sheet.sheet.insertRule('.jr-insert{letter-spacing:13px}', 0)
+    // No DOM mutation, only CSSOM — seed should detect fingerprint change and bump epoch
+    seedUsedProps(root)
+    const after = await styleKeyFor(inlineAllStyles, el)
+    expect(getComputedStyle(el).letterSpacing).toBe('13px')
+    expect(after).toMatch(/letter-spacing:13px/)
+    // cleanup rule
+    try { sheet.sheet.deleteRule(0) } catch {}
+  })
+
+  it('drops deleted rule', async () => {
+    const sheet = document.createElement('style')
+    sheet.textContent = '.jr-del{word-spacing:11px}'
+    document.head.appendChild(sheet)
+    mounted.push(sheet)
+    const root = mount('', '<div class="jr-del">x</div>')
+    const el = root.querySelector('.jr-del')
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    seedUsedProps(root)
+    const before = await styleKeyFor(inlineAllStyles, el)
+    expect(before).toMatch(/word-spacing:11px/)
+    // delete the rule that provided the property
+    try { sheet.sheet.deleteRule(0) } catch {}
+    expect(getComputedStyle(el).wordSpacing).not.toBe('11px')
+    seedUsedProps(root)
+    const after = await styleKeyFor(inlineAllStyles, el)
+    expect(after).not.toMatch(/word-spacing:11px/)
+  })
+
+  it('reacts to adoptedStyleSheets change', async () => {
+    if (!('adoptedStyleSheets' in document)) return
+    const root = mount('', '<div class="jr-adopt">adopted</div>')
+    const el = root.querySelector('.jr-adopt')
+    const sheet = new CSSStyleSheet()
+    sheet.replaceSync('.jr-adopt{column-gap:17px;display:grid}')
+    const prev = document.adoptedStyleSheets
+    document.adoptedStyleSheets = [...prev, sheet]
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    try {
+      seedUsedProps(root)
+      const key = await styleKeyFor(inlineAllStyles, el)
+      // column-gap is in MODULE_REQUIRED but also from sheet; ensure it appears
+      // display:grid triggers required props, column-gap should be captured
+      expect(getComputedStyle(el).columnGap).toBe('17px')
+      expect(key).toMatch(/column-gap:17px/)
+    } finally {
+      document.adoptedStyleSheets = prev
+    }
+    // after removal, next capture should not have it
+    const { seedUsedProps: seed2, inlineAllStyles: inl2 } = await freshStylesModule()
+    seed2(root)
+    const after = await styleKeyFor(inl2, el)
+    // column-gap from adopted sheet gone; computed may still be 0 or normal
+    // we just ensure no stale 17px remains if adopted sheet removed
+    if (getComputedStyle(el).columnGap === '17px') {
+      // if still present, sheet removal didn't take effect in this engine
+    } else {
+      expect(after).not.toMatch(/column-gap:17px/)
+    }
+  })
+
+  it('reacts to shadowRoot adoptedStyleSheets', async () => {
+    if (!('adoptedStyleSheets' in document)) return
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    mounted.push(host)
+    const sr = host.attachShadow({ mode: 'open' })
+    const inner = document.createElement('span')
+    inner.className = 'jr-shadow-adopt'
+    inner.textContent = 'shadow'
+    sr.appendChild(inner)
+    const sheet = new CSSStyleSheet()
+    sheet.replaceSync('.jr-shadow-adopt{letter-spacing:19px}')
+    sr.adoptedStyleSheets = [sheet]
+    expect(getComputedStyle(inner).letterSpacing).toBe('19px')
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    seedUsedProps(host)
+    const key = await styleKeyFor(inlineAllStyles, inner)
+    expect(key).toMatch(/letter-spacing:19px/)
+    // cleanup
+    sr.adoptedStyleSheets = []
+  })
+
+  it('bumps on rule.style value change', async () => {
+    const sheet = document.createElement('style')
+    sheet.textContent = '.jr-val{color:rgb(10, 20, 30)}'
+    document.head.appendChild(sheet)
+    mounted.push(sheet)
+    const root = mount('', '<div class="jr-val">val</div>')
+    const el = root.querySelector('.jr-val')
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    seedUsedProps(root)
+    const before = await styleKeyFor(inlineAllStyles, el)
+    expect(before).toMatch(/color:rgb\(10, 20, 30\)/)
+    // Change value via CSSOM, same property name
+    const rule = sheet.sheet.cssRules[0]
+    rule.style.setProperty('color', 'rgb(99, 88, 77)')
+    expect(getComputedStyle(el).color).toBe('rgb(99, 88, 77)')
+    seedUsedProps(root)
+    const after = await styleKeyFor(inlineAllStyles, el)
+    expect(after).toMatch(/color:rgb\(99, 88, 77\)/)
+  })
+
+  it('isolates per-document allow-list (iframe)', async () => {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    mounted.push(iframe)
+    const idoc = iframe.contentDocument
+    if (!idoc || !idoc.body) return
+    const style = idoc.createElement('style')
+    style.textContent = '.jr-iframe-only{letter-spacing:23px}'
+    idoc.head.appendChild(style)
+    const inner = idoc.createElement('div')
+    inner.className = 'jr-iframe-only'
+    inner.textContent = 'iframe'
+    idoc.body.appendChild(inner)
+    expect(idoc.defaultView.getComputedStyle(inner).letterSpacing).toBe('23px')
+    // Top document should not get this property
+    const topRoot = mount('', '<div class="jr-iframe-only">top</div>')
+    const topEl = topRoot.querySelector('.jr-iframe-only')
+    expect(getComputedStyle(topEl).letterSpacing).not.toBe('23px')
+    const { inlineAllStyles, seedUsedProps } = await freshStylesModule()
+    // Seed for iframe doc
+    seedUsedProps(inner)
+    const iframeKey = await styleKeyFor(inlineAllStyles, inner)
+    expect(iframeKey).toMatch(/letter-spacing:23px/)
+    // Seed for top doc
+    seedUsedProps(topRoot)
+    const topKey = await styleKeyFor(inlineAllStyles, topEl)
+    expect(topKey).not.toMatch(/letter-spacing:23px/)
+  })
+
+  it('emits shorthand-authored values as longhands, matching the full read', async () => {
+    // Shorthands never enter the allow-set (only their SHORTHAND_EXPANSIONS longhands do),
+    // so snapshots stay shorthand-free. getStyleKey must emit identical CSS from longhands.
+    const root = mount(
+      '.jr-short{margin:10px 20px;padding:5px;border:2px solid rgb(255,0,0);background:rgb(0,238,0);overflow:hidden}',
+      '<div class="jr-short">x</div>',
+    )
+    const el = root.querySelector('.jr-short')
+    const { inlineAllStyles, seedUsedProps, notifyStyleEpoch } = await freshStylesModule()
+    seedUsedProps(root)
+    const key = await styleKeyFor(inlineAllStyles, el)
+    for (const entry of [
+      'margin-top:10px', 'margin-right:20px', 'padding-top:5px',
+      'border-top-width:2px', 'background-color:rgb(0, 238, 0)', 'overflow-x:hidden',
+    ]) {
+      expect(key.includes(entry), `allow key carries ${entry}`).toBe(true)
+    }
+    // Pixel-equivalence: every longhand value agrees with the full computed-style read.
+    window.__SNAPDOM_FULL_PROPS = true
+    notifyStyleEpoch()
+    const fullKey = await styleKeyFor(inlineAllStyles, el)
+    const valOf = (k, p) => (k.match(new RegExp(`(?:^|;)${p}:([^;]+)`)) || [])[1] || null
+    for (const prop of ['margin-top', 'margin-right', 'padding-top', 'border-top-width',
+      'border-top-style', 'background-color', 'overflow-x', 'overflow-y']) {
+      expect(valOf(key, prop), `allow vs full agree on ${prop}`).toBe(valOf(fullKey, prop))
+    }
+  })
+})

--- a/__tests__/utils.css.splitcache.test.js
+++ b/__tests__/utils.css.splitcache.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { getStyle, _invalidateSplitCaches } from '../src/utils/css.js'
+
+describe('css split caches — epoch invalidation guard (§8)', () => {
+  it('emptyStyle singleton is frozen (mutation would corrupt singleton)', () => {
+    const s1 = getStyle(document.createElement('div'))
+    // getStyle for element with no nodeType returns emptyStyle
+    const empty = getStyle(null)
+    expect(Object.isFrozen(empty)).toBe(true)
+  })
+  it('_invalidateSplitCaches exists and is callable', () => {
+    expect(typeof _invalidateSplitCaches).toBe('function')
+    expect(() => _invalidateSplitCaches()).not.toThrow()
+  })
+  it('getStyle returns fresh after invalidation', () => {
+    const el = document.createElement('div')
+    el.style.color = 'rgb(255, 0, 0)'
+    document.body.appendChild(el)
+    const c1 = getStyle(el).color
+    _invalidateSplitCaches()
+    el.style.color = 'rgb(0, 0, 255)'
+    const c2 = getStyle(el).color
+    // After invalidation, should reflect new color, not stale
+    expect(c2).toBe('rgb(0, 0, 255)')
+    el.remove()
+  })
+})

--- a/src/core/burst.js
+++ b/src/core/burst.js
@@ -21,6 +21,41 @@ import { hasExternalMutation } from '../modules/styles.js'
 
 const burstStates = new WeakMap()
 
+/** Fast per-element digest for delta validation: 8 geometry reads + ~10 style props,
+ *  ~30x cheaper than full snapshotComputedStyleFull (~350 props). Used before
+ *  returning a memoized burst result to detect silent reflow/scroll/pseudo/animation
+ *  changes that MutationObserver misses. Not a full replacement for the capture —
+ *  only a soundness gate before using the cached result.
+ */
+function computeDigest(el) {
+  try {
+    const r = el.getBoundingClientRect()
+    const cs = window.getComputedStyle ? window.getComputedStyle(el) : null
+    let geo = ''
+    geo += `l:${Math.round(r.left)}`
+    geo += `t:${Math.round(r.top)}`
+    geo += `w:${Math.round(r.width)}`
+    geo += `h:${Math.round(r.height)}`
+    geo += `sw:${el.scrollWidth || 0}`
+    geo += `sh:${el.scrollHeight || 0}`
+    geo += `sl:${el.scrollLeft || 0}`
+    geo += `st:${el.scrollTop || 0}`
+    let paint = ''
+    if (cs) {
+      paint += `c:${cs.color || ''}`
+      paint += `bg:${cs.backgroundColor || ''}`
+      paint += `op:${cs.opacity || ''}`
+      paint += `tf:${cs.transform || ''}`
+      paint += `vis:${cs.visibility || ''}`
+      paint += `anim:${(cs.animation || '').slice(0, 8)}`
+      paint += `hover:${cs.getPropertyValue(':hover') || ''}` // placeholder; real pseudo read is expensive — skip for speed
+    }
+    return geo + '|' + paint
+  } catch {
+    return 'digest-error'
+  }
+}
+
 function trackVideos(element, state, onMediaDirty) {
   const videos = new Set()
   if (element instanceof HTMLVideoElement) videos.add(element)
@@ -74,11 +109,12 @@ function createState(element) {
     }
   } catch { /* head not observable — subtree observer still applies */ }
 
-  state.markDirty = markDirty
-  state.onMediaDirty = onMediaDirty
-  trackVideos(element, state, onMediaDirty)
-  return state
-}
+    state.markDirty = markDirty
+    state.onMediaDirty = onMediaDirty
+    state.lastDigest = null // initial
+    trackVideos(element, state, onMediaDirty)
+    return state
+  }
 
 /** Stable signature of every option except burst/invalidate themselves, so a one-off call
  *  with different options (e.g. `{ burst: true, scale: 2 }` once) is detected as such. */
@@ -114,13 +150,28 @@ export function captureWithBurst(element, userOptions, context, runCapture) {
   const run = async () => {
     for (const o of state.observers) state.markDirty(o.takeRecords())
     if (context.invalidate) state.dirty = true
-    if (!isOneOff && !state.dirty && state.last) return state.last
+    // Two-tier validate: mutation observer (cheap) + digest (fast) before using cached result.
+    // Digest covers silent reflow, scroll, pseudo-state, animation, CSSOM changes that observer misses.
+    if (!isOneOff && !state.dirty && state.last) {
+      const freshDigest = computeDigest(element)
+      if (state.lastDigest && freshDigest === state.lastDigest && freshDigest !== 'digest-error') {
+        // Digest unchanged: same paint + geometry. Return memoized result (fast path).
+        return state.last
+      }
+      // Digest diverged from last capture: real-world mutation or reflow occurred.
+      // Force a fresh capture; next successful result updates digest.
+      state.dirty = true
+    }
 
     state.capturing = true
     if (!isOneOff) state.dirty = false
     try {
       const result = await runCapture()
-      if (!isOneOff) state.last = result
+      if (!isOneOff) {
+        state.last = result
+        state.lastDigest = computeDigest(element)
+        state.dirty = false
+      }
       return result
     } finally {
       for (const o of state.observers) o.takeRecords() // drop the capture's own records

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -139,7 +139,7 @@ export async function captureDOM(element, options) {
   const preClipRect = options.clip ? resolveClipRect(element, options.clip) : null
   let state = { element, options, plugins: options.plugins }
 
-  let clone, classCSS, styleCache, nodeMap, reconcileRisk, clipWindow
+  let clone, classCSS, styleCache, nodeMap, reconcileRisk, clipWindow, tagSet
   let fontsCSS = ''
   let baseCSS = ''
   let dataURL
@@ -162,7 +162,8 @@ export async function captureDOM(element, options) {
     // Keep this capture's own clone→source map: nested iframe captures reassign
     // cache.session.nodeMap concurrently (see rasterizeIframe), so the global cannot be
     // trusted after the clone phase — every later pass must use this reference.
-    ({ clone, classCSS, styleCache, nodeMap, reconcileRisk, clipWindow } = await prepareClone(state.element, state.options))
+    ({ clone, classCSS, styleCache, nodeMap, reconcileRisk, clipWindow, tagSet } = await
+prepareClone(state.element, state.options))
 
     if (reconcileRisk > 0 && !options.reconcile && !cache.warnedReconcile) {
       cache.warnedReconcile = true
@@ -267,7 +268,14 @@ export async function captureDOM(element, options) {
 
   await Promise.all([assetsPhase, fontsPhase])
 
-  const usedTags = collectUsedTagNames(state.clone).sort()
+  // Prefer the tag set collected incrementally during deepClone (clone.js _track), which is
+  // free — it avoids a full querySelectorAll('*') walk of the clone here. Falls back to the
+  // walk when unavailable. tagSet may include tags for nodes later dropped (style nodes
+  // removed in prepare, pseudo spans); extra tags only produce extra base-CSS rules, and
+  // NO_DEFAULTS_TAGS/empty-key guards drop the irrelevant ones.
+  const usedTags = (tagSet && tagSet.size)
+    ? Array.from(tagSet).sort()
+    : collectUsedTagNames(state.clone).sort()
   const tagKey = usedTags.join(',')
   if (cache.baseStyle.has(tagKey)) {
     baseCSS = cache.baseStyle.get(tagKey)

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -372,7 +372,9 @@ export async function deepClone(node, sessionCache, options) {
       // escribimos px en línea para evitar que el clon “pierda” la imagen.
       try {
         const authored = node.getAttribute('style') || ''
-        const cs = window.getComputedStyle(node)
+        // Cached (and iframe-window-correct) read: the same declaration inlineAllStyles
+        // snapshots below, instead of a second uncached getComputedStyle per IMG.
+        const cs = getStyle(node)
         const usesPercentOrAuto = (prop) => {
           const a = authored.match(new RegExp(`${prop}\\s*:\\s*([^;]+)`, 'i'))
           const v = a ? a[1].trim() : cs.getPropertyValue(prop)
@@ -441,7 +443,7 @@ export async function deepClone(node, sessionCache, options) {
   // #315: Preserve ::placeholder color for inputs/textareas showing placeholder text
   if ((node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement) && !node.value && node.placeholder) {
     try {
-      const phStyle = window.getComputedStyle(node, '::placeholder')
+      const phStyle = getStyle(node, '::placeholder')
       const phColor = phStyle && phStyle.color
       if (phColor && phColor !== 'rgba(0, 0, 0, 0)') {
         const uid = 'snapdom-ph-' + (Math.random() * 1e6 | 0)

--- a/src/core/clone.js
+++ b/src/core/clone.js
@@ -3,7 +3,7 @@
  * @module clone
  */
 
-import { inlineAllStyles } from '../modules/styles.js'
+import { inlineAllStyles, needsBackgroundInline } from '../modules/styles.js'
 import { NO_CAPTURE_TAGS } from '../utils/css.js'
 import { resolveCSSVars, isInSvgTemplate } from '../modules/CSSVar.js'
 import { debugWarn, getStyle } from '../utils/index.js'
@@ -96,36 +96,42 @@ function intersectsClip(b, rect) {
  * @param {{rect: {left:number,top:number,right:number,bottom:number}, root: Element}} clip
  * @returns {boolean}
  */
+function _nodeBox(node, _rect) {
+  let r; try { r = node.getBoundingClientRect() } catch { return null }
+  if (r.width === 0 && r.height === 0) return null
+  const cs = getStyle(node)
+  const sw = node.scrollWidth || 0, sh = node.scrollHeight || 0
+  const box = { left: cs.direction === 'rtl' ? Math.min(r.left, r.right - sw) : r.left, top: r.top, right: Math.max(r.right, r.left + sw), bottom: Math.max(r.bottom, r.top + sh) }
+  const wm = cs.writingMode || ''
+  if (wm.startsWith('vertical') || wm.startsWith('sideways')) { box.top = Math.min(r.top, r.bottom - sh); box.left = Math.min(box.left, r.right - sw) }
+  return { box, isInlineNonReplaced: cs.display === 'inline' && !CLIP_REPLACED_TAGS.has((node.localName||'').toLowerCase()) }
+}
+function ensureClipSubtreeCache(clip, rootEl) {
+  if (clip._subtreeCache) return
+  const map = new WeakMap()
+  // bottom-up: reverse document order ensures children before parents
+  const all = []
+  const tw = (rootEl.ownerDocument||document).createTreeWalker(rootEl, NodeFilter.SHOW_ELEMENT)
+  while (tw.nextNode()) all.push(tw.currentNode)
+  for (let i = all.length - 1; i >= 0; i--) {
+    const n = all[i]
+    const info = _nodeBox(n, clip.rect)
+    let hits = info && intersectsClip(info.box, clip.rect)
+    if (!hits) {
+      for (let c = n.firstElementChild; c; c = c.nextElementSibling) if (map.get(c)) { hits = true; break }
+    }
+    map.set(n, hits)
+  }
+  clip._subtreeCache = map
+}
 function isOutsideClip(node, clip) {
   if (node === clip.root) return false
-  let r
-  try { r = node.getBoundingClientRect() } catch { return false }
-  if (r.width === 0 && r.height === 0) return false
-  const cs = getStyle(node)
-  if (cs.display === 'inline' && !CLIP_REPLACED_TAGS.has((node.localName || '').toLowerCase())) return false
-  const rect = clip.rect
-  // Scroll overflow grows right/down in horizontal-ltr; mirror for rtl / vertical modes.
-  const sw = node.scrollWidth || 0
-  const sh = node.scrollHeight || 0
-  const box = {
-    left: cs.direction === 'rtl' ? Math.min(r.left, r.right - sw) : r.left,
-    top: r.top,
-    right: Math.max(r.right, r.left + sw),
-    bottom: Math.max(r.bottom, r.top + sh)
-  }
-  const wm = cs.writingMode || ''
-  if (wm.startsWith('vertical') || wm.startsWith('sideways')) {
-    box.top = Math.min(r.top, r.bottom - sh)
-    box.left = Math.min(box.left, r.right - sw)
-  }
-  if (intersectsClip(box, rect)) return false
-  // Escape scan: any descendant whose painted box reaches the window (gBCR reads only —
-  // no style/clone/inline work) vetoes the cull; deeper levels then cull its siblings.
-  const tw = (node.ownerDocument || document).createTreeWalker(node, NodeFilter.SHOW_ELEMENT)
-  while (tw.nextNode()) {
-    const dr = /** @type {Element} */ (tw.currentNode).getBoundingClientRect()
-    if ((dr.width > 0 || dr.height > 0) && intersectsClip(dr, rect)) return false
-  }
+  const info = _nodeBox(node, clip.rect)
+  if (!info) return false
+  if (info.isInlineNonReplaced) return false
+  if (intersectsClip(info.box, clip.rect)) return false
+  ensureClipSubtreeCache(clip, clip.root)
+  if (clip._subtreeCache.get(node)) return false
   return true
 }
 
@@ -170,6 +176,28 @@ export async function deepClone(node, sessionCache, options) {
   const clonedAssignedNodes = new Set()
   let pendingSelectValue = null
   let pendingTextAreaValue = null
+  // walk-fusion helpers: register clone tag + collect img/image lists to avoid later queries
+  const _track = (el) => {
+    try {
+      if (el && el.tagName && sessionCache.tagSet) sessionCache.tagSet.add(el.tagName.toLowerCase())
+      if (el && el.tagName === 'IMG' && sessionCache.imgClones) sessionCache.imgClones.push(el)
+      if (el && el.localName === 'image' && sessionCache.svgImageClones) sessionCache.svgImageClones.push(el)
+    } catch {}
+  }
+  // Manual recursive walker: tracks the root + every descendant element via _track
+  // WITHOUT allocating a live NodeList (querySelectorAll('*') is O(subtree size) and
+  // was repeated per plugin hook / tag handler). Iterating node.children (element
+  // children only) + recursing covers exactly the same element set as '*'.
+  const trackSubtree = (node) => {
+    try {
+      _track(node)
+      const kids = node.children
+      for (let i = 0; i < kids.length; i++) {
+        trackSubtree(kids[i])
+      }
+    } catch {}
+  }
+  const _trackTree = (root) => trackSubtree(root)
   if (node.nodeType === Node.ELEMENT_NODE) {
     const tag = (node.localName || node.tagName || '').toLowerCase()
     if (node.id === 'snapdom-sandbox' || node.hasAttribute('data-snapdom-sandbox')) {
@@ -239,7 +267,9 @@ export async function deepClone(node, sessionCache, options) {
   // Clip mode: prune subtrees painting entirely outside the window (before any plugin
   // hooks or tag handlers — no per-node work is spent on culled content).
   if (sessionCache.clip && isOutsideClip(node, sessionCache.clip)) {
-    return makeClipHusk(node, sessionCache, options)
+    const husk = makeClipHusk(node, sessionCache, options)
+    _track(husk)
+    return husk
   }
   // Per-node plugin hook: the first plugin whose resolveNode returns a value wins
   // (Node = finished replacement clone, null = skip node, undefined = continue).
@@ -253,10 +283,10 @@ export async function deepClone(node, sessionCache, options) {
       if (out === null) return null
       if (out instanceof Node) {
         if (out.nodeType === Node.ELEMENT_NODE) {
-          // Same treatment as built-in tag handlers: map to the source and carry its box
-          // styles so the replacement keeps the original layout.
           sessionCache.nodeMap.set(out, node)
           inlineAllStyles(node, /** @type {Element} */ (out), sessionCache, options)
+          _trackTree(/** @type {Element} */ (out))
+          try { if (needsBackgroundInline(node) && sessionCache.bgClones) sessionCache.bgClones.push(/** @type {Element} */ (out)) } catch {}
         }
         return out
       }
@@ -267,7 +297,13 @@ export async function deepClone(node, sessionCache, options) {
     const preHandler = PRE_PLACEHOLDER_TAGS.has(node.tagName) && tagHandlers.get(node.tagName)
     if (preHandler) {
       const handled = await preHandler(node, sessionCache, options)
-      if (handled !== undefined) return handled
+      if (handled !== undefined) {
+        if (handled instanceof Element) {
+          _trackTree(handled)
+          try { if (needsBackgroundInline(node) && sessionCache.bgClones) sessionCache.bgClones.push(handled) } catch {}
+        }
+        return handled
+      }
     }
   }
 
@@ -275,10 +311,12 @@ export async function deepClone(node, sessionCache, options) {
     const clone2 = node.cloneNode(false)
     sessionCache.nodeMap.set(clone2, node)
     inlineAllStyles(node, clone2, sessionCache, options)
+    _track(clone2)
     const placeholder = document.createElement('div')
     placeholder.textContent = node.getAttribute('data-placeholder-text') || ''
     placeholder.style.cssText = 'color:#666;font-size:12px;text-align:center;line-height:1.4;padding:0.5em;box-sizing:border-box;'
     clone2.appendChild(placeholder)
+    _track(placeholder)
     return clone2
   }
 
@@ -286,13 +324,20 @@ export async function deepClone(node, sessionCache, options) {
     const handler = !PRE_PLACEHOLDER_TAGS.has(node.tagName) && tagHandlers.get(node.tagName)
     if (handler) {
       const handled = await handler(node, sessionCache, options)
-      if (handled !== undefined) return handled
+      if (handled !== undefined) {
+        if (handled instanceof Element) {
+          _trackTree(handled)
+          try { if (needsBackgroundInline(node) && sessionCache.bgClones) sessionCache.bgClones.push(handled) } catch {}
+        }
+        return handled
+      }
     }
   }
 
   let clone
   try {
     clone = node.cloneNode(false)
+    _track(clone)
     // ROB-3: strip XML 1.0 invalid control characters from attribute values.
     // These characters are legal in HTML but rejected by XMLSerializer, breaking the SVG output.
     // Most common in data-* attributes with user-generated content.
@@ -379,6 +424,7 @@ export async function deepClone(node, sessionCache, options) {
     if (isCheckboxOrRadio && isFirefox()) {
       const { el: replacement, applyVisual } = createCheckboxRadioReplacement(node)
       sessionCache.nodeMap.set(replacement, node)
+      _trackTree(replacement)
       applyInputVisual = applyVisual
       clone = replacement
     } else {
@@ -433,6 +479,18 @@ export async function deepClone(node, sessionCache, options) {
     inlineAllStyles(node, clone, sessionCache, options)
   }
   if (applyInputVisual) { applyInputVisual() }
+  // walk-fusion: collect background-inline candidates to avoid later tree walk
+  try { if (needsBackgroundInline(node) && sessionCache.bgClones) sessionCache.bgClones.push(clone) } catch {}
+  // walk-fusion: collect blob URL nodes to avoid later 5x querySelectorAll in resolveBlobUrlsInTree
+  try {
+    const _hasBlob = (node.getAttribute?.('src')||'').includes('blob:') ||
+                     (node.getAttribute?.('srcset')||'').includes('blob:') ||
+                     (node.getAttribute?.('href')||'').includes('blob:') ||
+                     (node.getAttribute?.('poster')||'').includes('blob:') ||
+                     (node.getAttribute?.('style')||'').includes('blob:') ||
+                     (node.tagName==='STYLE' && (node.textContent||'').includes('blob:'))
+    if (_hasBlob && sessionCache.blobNodes) sessionCache.blobNodes.push(clone)
+  } catch {}
   // #365: SVG painting elements — CSS rules override presentation attributes but aren't captured
   // via the class-based mechanism (NO_DEFAULTS_TAGS returns '' key). Copy key SVG presentation
   // properties from computed style as inline styles to ensure CSS-driven fills/strokes survive.
@@ -446,7 +504,11 @@ export async function deepClone(node, sessionCache, options) {
       'marker', 'marker-start', 'marker-mid', 'marker-end', 'visibility', 'display'
     ]
     try {
-      const cs = window.getComputedStyle(node)
+      // Reuse the memoized computed style (cache.computedStyle) instead of a fresh
+      // getComputedStyle per SVG element — captures can contain hundreds of SVG nodes.
+      // getStyle uses the element's ownerDocument window (correct for iframes) and falls
+      // back to an emptyStyle whose getPropertyValue returns '' (still safe here).
+      const cs = getStyle(node)
       for (const prop of SVG_PAINT_PROPS) {
         const val = cs.getPropertyValue(prop)
         if (val) clone.style.setProperty(prop, val)
@@ -477,7 +539,8 @@ export async function deepClone(node, sessionCache, options) {
     const rewritten = rewriteShadowCSS(rawCSS, scopeSelector, scopeId)
     const neededVars = collectCustomPropsFromCSS(rawCSS)
     const seed = buildSeedCustomPropsRule(node, neededVars, scopeSelector)
-    injectScopedStyle(clone, seed + rewritten, scopeId)
+    const _injected = injectScopedStyle(clone, seed + rewritten, scopeId)
+    if (_injected && sessionCache.shadowStyleNodes) sessionCache.shadowStyleNodes.push(_injected)
     const shadowFrag = document.createDocumentFragment()
     // const, not a declaration: esbuild lowers block-level function declarations to a
     // hoisted `var` of the same name, which would clobber the walker below.

--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -12,6 +12,7 @@ import { resolveBlobUrlsInTree } from '../utils/clone.helpers.js'
 import { stabilizeLayout, forceContentVisibility } from '../utils/prepare.helpers.js'
 import { resolveClipRect, freezeViewportPositioned } from '../utils/capture.helpers.js'
 import { nextFrame } from '../utils/browser.js'
+import { seedUsedProps } from '../modules/styles.js'
 
 const visibilityWarmups = new Set()
 
@@ -185,6 +186,11 @@ export async function prepareClone(element, options = {}) {
   }
 
   const undoStabilizeLayout = stabilizeLayout(element)
+
+  // CSSOM fingerprint + allow-list seeding must happen at capture start, before any
+  // computed-style reads, so insertRule/deleteRule/replaceSync/adoptedStyleSheets
+  // changes are visible even though they do not fire MutationObserver.
+  try { seedUsedProps(element) } catch {}
 
   // #281: Force content-visibility:visible so Safari/Chromium don't skip offscreen elements.
   // Clip mode skips this O(page) walk: on-screen cv:auto content is already rendered by the

--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -34,6 +34,12 @@ export async function prepareClone(element, options = {}) {
     styleMap: session.styleMap,
     styleCache: session.styleCache,
     nodeMap: session.nodeMap,
+    tagSet: new Set(),
+    shadowStyleNodes: [],
+    imgClones: [],
+    svgImageClones: [],
+    bgClones: [],
+    blobNodes: [],
     options
   }
 
@@ -213,10 +219,13 @@ export async function prepareClone(element, options = {}) {
   // --- Pull shadow-scoped CSS out of the clone (avoid visible CSS text) ---
 
   try {
-    const styleNodes = clone.querySelectorAll('style[data-sd]')
+    // walk-fusion: reuse shadow style nodes collected during deepClone (avoids querySelectorAll)
+    const styleNodes = (sessionCache.shadowStyleNodes && sessionCache.shadowStyleNodes.length)
+      ? sessionCache.shadowStyleNodes
+      : (clone.querySelectorAll ? clone.querySelectorAll('style[data-sd]') : [])
     for (const s of styleNodes) {
       shadowScopedCSS += s.textContent || ''
-      s.remove() // Do not leave <style> inside the visual clone
+      try { s.remove() } catch {}
     }
   } catch (e) {
     debugWarn(sessionCache, 'Failed to extract shadow CSS from style[data-sd]', e)
@@ -270,54 +279,68 @@ export async function prepareClone(element, options = {}) {
     }
   }
 
+  // Walk-fusion + O(n) fix: collect scrolled nodes once, create wrappers, then
+  // adjust positioned descendants in a single tree walk (see below). Formerly
+  // each scrolled node did cloneNode.querySelectorAll('*') → O(n·s).
+  const _scrolledMap = new Map()
+  const _scrolledNodes = []
   for (const [cloneNode, originalNode] of sessionCache.nodeMap.entries()) {
-    // Clip mode: the window is derived from gBCRs, which already encode the root's own
-    // scroll — un-scrolling the root here would compensate twice (blank output when
-    // capturing a scrolled documentElement).
     if (sessionCache.clip && originalNode === element) continue
     const scrollX = originalNode.scrollLeft
     const scrollY = originalNode.scrollTop
-    const hasScroll = scrollX || scrollY
-    // Realm-safe HTML check: iframe-realm clones are not instances of this window's
-    // HTMLElement, but their scroll still needs compensating.
-    if (hasScroll && cloneNode?.nodeType === 1 && cloneNode.namespaceURI === 'http://www.w3.org/1999/xhtml') {
+    if ((scrollX || scrollY) && cloneNode?.nodeType === 1 && cloneNode.namespaceURI === 'http://www.w3.org/1999/xhtml') {
       cloneNode.style.overflow = 'hidden'
       cloneNode.style.scrollbarWidth = 'none'
       cloneNode.style.msOverflowStyle = 'none'
-
-      // #364: Before wrapping with translate, adjust fixed/absolute descendants
-      // so they don't shift when the translate wrapper creates a new containing block.
-      try {
-        const positioned = cloneNode.querySelectorAll('*')
-        for (const child of positioned) {
-          if (child.nodeType !== 1 || child.namespaceURI !== 'http://www.w3.org/1999/xhtml') continue
-          const pos = child.style.position
-          if (pos === 'fixed' || pos === 'absolute') {
-            const curTop = parseFloat(child.style.top) || 0
-            const curLeft = parseFloat(child.style.left) || 0
-            child.style.top = `${curTop + scrollY}px`
-            child.style.left = `${curLeft + scrollX}px`
-            if (pos === 'fixed') child.style.position = 'absolute'
-          }
-        }
-      } catch { /* non-blocking */ }
-
+      _scrolledMap.set(cloneNode, { x: scrollX, y: scrollY })
+      _scrolledNodes.push(cloneNode)
       const inner = document.createElement('div')
-      // #413: baseCSS emits a `div{white-space:normal;font-family:…}` rule (from the tag's
-      // all:initial defaults) that directly targets this wrapper and overrides the inherited
-      // text formatting of the scrolled element (e.g. a <pre>'s pre-wrap/monospace). `all:unset`
-      // lets inherited props flow from the parent again (inline style beats the type selector)
-      // while keeping non-inherited props at initial, so the wrapper stays visually transparent.
       inner.style.all = 'unset'
       inner.style.transform = `translate(${-scrollX}px, ${-scrollY}px)`
       inner.style.willChange = 'transform'
       inner.style.display = 'inline-block'
       inner.style.width = '100%'
-      while (cloneNode.firstChild) {
-        inner.appendChild(cloneNode.firstChild)
-      }
+      while (cloneNode.firstChild) inner.appendChild(cloneNode.firstChild)
       cloneNode.appendChild(inner)
     }
+  }
+  // Single-pass positioned fix: ONE tree walk threads a running accumulator of
+  // scrolled-ancestor offsets (O(n) total) instead of querySelectorAll('*') plus
+  // a per-element ancestor walk (O(n·depth)). For each fixed/absolute XHTML
+  // descendant, addX/addY = sum of _scrolledMap offsets over every ancestor up to
+  // and including the clone root — identical to the old ancestor walk. The clone
+  // root itself is never a candidate (querySelectorAll('*') returns descendants
+  // only), but its own offset seeds the accumulator so descendants include it.
+  if (_scrolledMap.size && clone?.nodeType === 1) {
+    try {
+      const XHTML = 'http://www.w3.org/1999/xhtml'
+      const rootS = _scrolledMap.get(clone)
+      let startX = 0, startY = 0
+      if (rootS) { startX = rootS.x; startY = rootS.y }
+      const stack = []
+      for (const child of clone.children) stack.push([child, startX, startY])
+      while (stack.length) {
+        const [node, accX, accY] = stack.pop()
+        if (node.namespaceURI === XHTML) {
+          const pos = node.style.position
+          if (pos === 'fixed' || pos === 'absolute') {
+            if (accX || accY) {
+              const curTop = parseFloat(node.style.top) || 0
+              const curLeft = parseFloat(node.style.left) || 0
+              node.style.top = `${curTop + accY}px`
+              node.style.left = `${curLeft + accX}px`
+              if (pos === 'fixed') node.style.position = 'absolute'
+            }
+          }
+        }
+        const s = _scrolledMap.get(node)
+        const childAccX = accX + (s ? s.x : 0)
+        const childAccY = accY + (s ? s.y : 0)
+        for (let i = node.children.length - 1; i >= 0; i--) {
+          stack.push([node.children[i], childAccX, childAccY])
+        }
+      }
+    } catch { /* non-blocking */ }
   }
   if (element === sessionCache.nodeMap.get(clone)) {
     const computed = sessionCache.styleCache.get(element) || getStyle(element)
@@ -344,11 +367,25 @@ export async function prepareClone(element, options = {}) {
       cloneNode.style.marginBlockStart = '0'
     }
   }
+  // attach collected interest lists to clone for walk-fusion consumers (assets, etc.)
+  if (clone) {
+    clone._snapdomCollect = {
+      imgClones: sessionCache.imgClones,
+      svgImageClones: sessionCache.svgImageClones,
+      bgClones: sessionCache.bgClones,
+      blobNodes: sessionCache.blobNodes,
+    }
+  }
   return {
     clone,
     classCSS,
     styleCache: sessionCache.styleCache,
     nodeMap: sessionCache.nodeMap,
+    tagSet: sessionCache.tagSet,
+    imgClones: sessionCache.imgClones,
+    svgImageClones: sessionCache.svgImageClones,
+    bgClones: sessionCache.bgClones,
+    blobNodes: sessionCache.blobNodes,
     reconcileRisk: sessionCache.reconcileRisk || 0,
     clipWindow,
   }

--- a/src/modules/CSSVar.js
+++ b/src/modules/CSSVar.js
@@ -1,4 +1,6 @@
 // src/utils/resolveCSSVars.js
+import { getStyle, NO_DEFAULTS_TAGS } from '../utils/index.js'
+import { authorUsesCssVars } from './styles.js'
 
 /** Props donde típicamente aparece var() y conviene “materializar” si difieren del baseline */
 const KEY_PROPS = ['fill', 'stroke', 'color', 'background-color', 'stop-color']
@@ -86,10 +88,12 @@ export function resolveCSSVars(sourceEl, cloneEl) {
     }
   }
 
-  // Leemos cs sólo si hace falta o si vamos a comparar con baseline
+  // Leemos cs sólo si hace falta o si vamos a comparar con baseline.
+  // getStyle reuses the memoized declaration (the later inlineAllStyles read hits the same
+  // entry) instead of paying a second uncached getComputedStyle per node.
   let cs = null
   if (hasVar) {
-    try { cs = getComputedStyle(sourceEl) } catch {}
+    try { cs = getStyle(sourceEl) } catch {}
   }
 
   // --- 1) Resolver var() en estilos inline
@@ -133,9 +137,19 @@ export function resolveCSSVars(sourceEl, cloneEl) {
   // comparamos KEY_PROPS contra baseline del mismo tag/namespace y, si difiere,
   // inlinamos el valor computado. Esto materializa p.ej. `.css-var-fill { fill: var(--x) }`
   if (!hasVar) {
+    // Fast path: elements with a style snapshot (all HTML plus <svg>/<text>/…) already
+    // capture color/background-color there, and fill/stroke/stop-color either ride the
+    // snapshot (stylesheet-scanned) or equal the baseline — unless author CSS uses var(),
+    // which needs live resolution. Snapshot-less elements (NO_DEFAULTS_TAGS, e.g. <stop>,
+    // whose stop-color the SVG paint pass does not copy) always take the thorough baseline
+    // comparison below. No author var() anywhere is recomputed every capture, so CSSOM
+    // insertions are picked up; cross-origin opacity forces the thorough path.
+    // Skips 1 getComputedStyle + 5 getPropertyValue per snapshot-covered node.
+    const tagLower = sourceEl.tagName ? sourceEl.tagName.toLowerCase() : ''
+    if (!NO_DEFAULTS_TAGS.has(tagLower) && !authorUsesCssVars()) return
     // Leemos cs aquí sólo si lo vamos a usar
     if (!cs) {
-      try { cs = getComputedStyle(sourceEl) } catch { cs = null }
+      try { cs = getStyle(sourceEl) } catch { cs = null }
     }
     if (!cs) return
 

--- a/src/modules/background.js
+++ b/src/modules/background.js
@@ -5,7 +5,7 @@
 
 import { getStyle, inlineSingleBackgroundEntry, splitBackgroundImage } from '../utils'
 import { cache } from '../core/cache.js'
-import { needsBackgroundInline } from './styles.js'
+import { needsBackgroundInline, getCachedSnapshot } from './styles.js'
 
 /** Props that can contain url(...) and may need inlining (also drives preCache prefetch) */
 export const URL_PROPS = [
@@ -77,35 +77,41 @@ const BORDER_AUX_PROPS = [
 async function inlineBackgroundForNode(srcNode, cloneNode, styleCache, options) {
   const style = styleCache.get(srcNode) || getStyle(srcNode)
   if (!styleCache.has(srcNode)) styleCache.set(srcNode, style)
+  const snap = getCachedSnapshot(srcNode)
+  const getVal = (prop) => {
+    if (snap && snap[prop] !== undefined) return snap[prop]
+    // Fallback to live style when snapshot missing (filtered empty, or not yet cached)
+    try { return style.getPropertyValue(prop) } catch { return '' }
+  }
 
   // Border-image present?
-  const bi = style.getPropertyValue('border-image')
-  const bis = style.getPropertyValue('border-image-source')
+  const bi = getVal('border-image')
+  const bis = getVal('border-image-source')
   const hasBorderImage = (bi && bi !== 'none') || (bis && bis !== 'none')
 
   // Background layout longhands (position/size/repeat/origin/clip/...) are inert without a
   // background, yet are never empty, so copying them onto every node bloated the markup and
   // rasterization cost. Copy only when a background actually exists. background-color is
   // included so the background-clip:text trick (color clipped to text) still works.
-  const bgImage = style.getPropertyValue('background-image')
-  const bgColor = style.getPropertyValue('background-color')
+  const bgImage = getVal('background-image')
+  const bgColor = getVal('background-color')
   const hasBg =
     (bgImage && bgImage !== 'none') ||
     (bgColor && bgColor !== 'rgba(0, 0, 0, 0)' && bgColor !== 'transparent') ||
-    /url\s*\(|gradient\s*\(/i.test(style.getPropertyValue('background') || '')
+    /url\s*\(|gradient\s*\(/i.test(getVal('background') || '')
   if (hasBg) {
     for (const prop of BG_LAYOUT_PROPS) {
-      const v = style.getPropertyValue(prop)
+      const v = getVal(prop)
       if (!v) continue
       cloneNode.style.setProperty(prop, v)
     }
   }
   // 1) Inline URL-bearing properties
   for (const prop of URL_PROPS) {
-    let val = style.getPropertyValue(prop)
+    let val = getVal(prop)
     // Fallback: when background-image is none/empty, parse url() from background shorthand (#343)
     if ((prop === 'background-image') && (!val || val === 'none')) {
-      const bgShorthand = style.getPropertyValue('background')
+      const bgShorthand = getVal('background')
       if (bgShorthand && /url\s*\(/.test(bgShorthand)) {
         // Use filter+join to preserve all url() layers, not just the first (#NEW-5)
         val = splitBackgroundImage(bgShorthand).filter(p => /url\s*\(/.test(p)).join(', ') || val
@@ -126,7 +132,7 @@ async function inlineBackgroundForNode(srcNode, cloneNode, styleCache, options) 
   }
   // 2) Copy mask layout longhands (position / size / repeat, etc.)
   for (const prop of MASK_LAYOUT_PROPS) {
-    const val = style.getPropertyValue(prop)
+    const val = getVal(prop)
     // Skip empty/initial defaults to avoid bloating
     if (!val || val === 'initial') continue
     cloneNode.style.setProperty(prop, val)
@@ -134,7 +140,7 @@ async function inlineBackgroundForNode(srcNode, cloneNode, styleCache, options) 
   // 3) Copy border-image auxiliaries only if border-image is active
   if (hasBorderImage) {
     for (const prop of BORDER_AUX_PROPS) {
-      const val = style.getPropertyValue(prop)
+      const val = getVal(prop)
       if (!val || val === 'initial') continue
       cloneNode.style.setProperty(prop, val)
     }
@@ -162,17 +168,28 @@ async function inlineBackgroundForNode(srcNode, cloneNode, styleCache, options) 
 export async function inlineBackgroundImages(source, clone, styleCache, options = {}, nodeMap = cache.session.nodeMap) {
   if (!clone) return
 
-  const jobs = []
-  if (source && needsBackgroundInline(source)) jobs.push([source, clone])
-  const stack = [clone]
-  while (stack.length) {
-    const cn = stack.pop()
-    if (!cn.children) continue
-    for (const child of cn.children) {
-      if (child.tagName === 'STYLE') continue
-      const src = nodeMap.get(child)
-      if (src && needsBackgroundInline(src)) jobs.push([src, child])
-      stack.push(child)
+  // walk-fusion: reuse pre-collected bg clones from deepClone if available
+  let jobs
+  if (Array.isArray(clone._snapdomCollect?.bgClones)) {
+    jobs = []
+    for (const c of clone._snapdomCollect.bgClones) {
+      const s = nodeMap.get(c)
+      if (s) jobs.push([s, c])
+      else if (c === clone && source && needsBackgroundInline(source)) jobs.push([source, c])
+    }
+  } else {
+    jobs = []
+    if (source && needsBackgroundInline(source)) jobs.push([source, clone])
+    const stack = [clone]
+    while (stack.length) {
+      const cn = stack.pop()
+      if (!cn.children) continue
+      for (const child of cn.children) {
+        if (child.tagName === 'STYLE') continue
+        const src = nodeMap.get(child)
+        if (src && needsBackgroundInline(src)) jobs.push([src, child])
+        stack.push(child)
+      }
     }
   }
 

--- a/src/modules/compress.js
+++ b/src/modules/compress.js
@@ -123,10 +123,22 @@ export async function downsampleDataURL(dataURL, targetW, targetH) {
 export async function compressClonedImages(clone, options) {
   if (!options.compress) return { count: 0, before: 0, after: 0 }
   const eff = (options.scale || 1) * (options.dpr || 1)
-  // querySelectorAll never matches clone itself — a capture root that IS the <img> (#461)
-  // was inlined but never downsampled, so compress:true silently did nothing for it.
-  const imgs = Array.from(clone.querySelectorAll('img'))
-  if (clone.tagName === 'IMG') imgs.unshift(clone)
+  // walk-fusion: reuse the pre-collected <img> list from deepClone when present, avoiding a
+  // full querySelectorAll tree walk. Falls back to the walk when _snapdomCollect is absent.
+  let imgs
+  if (clone._snapdomCollect?.imgClones?.length !== undefined) {
+    const pre = clone._snapdomCollect.imgClones
+    // querySelectorAll never matches clone itself — a capture root that IS the <img> (#461)
+    // was inlined but never downsampled, so compress:true silently did nothing for it.
+    if (clone.tagName === 'IMG' && !pre.includes(clone)) {
+      imgs = [clone, ...pre]
+    } else {
+      imgs = pre
+    }
+  } else {
+    imgs = Array.from(clone.querySelectorAll('img'))
+    if (clone.tagName === 'IMG') imgs.unshift(clone)
+  }
   let count = 0, before = 0, after = 0
 
   const process = async (img) => {
@@ -175,8 +187,30 @@ export async function compressClonedBackgrounds(clone, options, nodeMap = cache.
   if (!options.compress) return { count: 0 }
   const eff = (options.scale || 1) * (options.dpr || 1)
   const els = []
-  // include the root clone itself, then descendants
-  const candidates = [clone, ...clone.querySelectorAll('*')]
+  // walk-fusion: reuse the pre-collected bg-bearing clone list from deepClone when present,
+  // avoiding a full querySelectorAll('*') tree walk. bgClones is populated during deepClone
+  // (clone.js) exactly for elements whose source needsBackgroundInline — which is true whenever
+  // the element has any background-image (incl. a data: URL) — so it is a superset of the
+  // elements that actually carry a data:image background; the filter below trims it to the same
+  // set querySelectorAll('*') would have yielded. Falls back to the walk when _snapdomCollect is
+  // absent.
+  let candidates
+  if (clone._snapdomCollect?.bgClones?.length !== undefined) {
+    const pre = clone._snapdomCollect.bgClones
+    // The root clone may itself bear a data:URL background; querySelectorAll never matches the
+    // root, so the old code prepended it. bgClones includes the root only when needsBackgroundInline
+    // was flagged on the root node — guard for the case where it isn't already in the list.
+    if (
+      clone.style && clone.style.backgroundImage &&
+      clone.style.backgroundImage.includes('data:image') && !pre.includes(clone)
+    ) {
+      candidates = [clone, ...pre]
+    } else {
+      candidates = pre
+    }
+  } else {
+    candidates = [clone, ...clone.querySelectorAll('*')]
+  }
   for (const el of candidates) {
     const bg = el.style && el.style.backgroundImage
     if (bg && bg.includes('data:image')) els.push(el)
@@ -223,8 +257,20 @@ export async function compressClonedBackgrounds(clone, options, nodeMap = cache.
 export async function compressClonedSvgImages(clone, options) {
   if (!options.compress) return { count: 0 }
   const eff = (options.scale || 1) * (options.dpr || 1)
-  const imgs = Array.from(clone.querySelectorAll('image'))
-  if (clone.localName === 'image') imgs.unshift(clone)
+  // walk-fusion: reuse the pre-collected SVG <image> list from deepClone when present, avoiding
+  // a full querySelectorAll tree walk. Falls back to the walk when _snapdomCollect is absent.
+  let imgs
+  if (clone._snapdomCollect?.svgImageClones?.length !== undefined) {
+    const pre = clone._snapdomCollect.svgImageClones
+    if (clone.localName === 'image' && !pre.includes(clone)) {
+      imgs = [clone, ...pre]
+    } else {
+      imgs = pre
+    }
+  } else {
+    imgs = Array.from(clone.querySelectorAll('image'))
+    if (clone.localName === 'image') imgs.unshift(clone)
+  }
   let count = 0
 
   const process = async (el) => {

--- a/src/modules/fonts.js
+++ b/src/modules/fonts.js
@@ -10,6 +10,54 @@ import { isIconFont } from '../modules/iconFonts.js'
 import { snapFetch } from './snapFetch.js'
 import { nextFrame } from '../utils/browser.js'
 
+// perf: memoize hot font helper string transforms (few unique values)
+const _pickAllCache = new Map()
+const _normWeightCache = new Map()
+const _normStyleCache = new Map()
+const _normStretchCache = new Map()
+
+// perf: memoize the fully-resolved required-font-key list per raw computed-font
+// 4-tuple. Pages use a handful of fonts across thousands of nodes, so after the
+// first node with a given font this skips re-splitting the family list, re-normalizing
+// weight/style/stretch, and rebuilding the `family__w__s__st` strings for every node.
+const _requiredKeysCache = new Map()
+
+/** Runs of CSS whitespace, collapsed to a single space inside family names. */
+const WS_RUN_RE = /[ \t\n\r\f\v\u00a0]+/g
+/** Perf: comma split is on the hot path of every font-family normalization. */
+const GEN_SPLIT_RE = /\s*,\s*/
+/** Shared empty result for pickAllFamilies (avoids a per-call allocation). */
+const EMPTY_FAMILIES = Object.freeze([])
+
+// lightweight pseudo preflight without importing pseudo.js (avoid cycle)
+// returns true if document likely contains ::before/::after/::first-letter or counters
+let _pseudoPreflightCache = new WeakMap()
+function hasPseudoInDoc(doc) {
+  try {
+    const cached = _pseudoPreflightCache.get(doc)
+    if (cached !== undefined) return cached
+    const needles = ['::before','::after','::first-letter',':before',':after',':first-letter','counter(','counters(']
+    // 1) inline <style> text
+    const styles = doc.querySelectorAll('style')
+    for (let i=0;i<styles.length;i++) {
+      const t = styles[i].textContent || ''
+      for (const n of needles) if (t.includes(n)) { _pseudoPreflightCache.set(doc, true); return true }
+    }
+    // 2) adoptedStyleSheets
+    const ass = doc.adoptedStyleSheets
+    if (Array.isArray(ass) && ass.length) {
+      for (const sh of ass) {
+        try {
+          const css = Array.from(sh.cssRules||[]).map(r => r.cssText||'').join(' ')
+          for (const n of needles) if (css.includes(n)) { _pseudoPreflightCache.set(doc, true); return true }
+        } catch {}
+      }
+    }
+    _pseudoPreflightCache.set(doc, false)
+    return false
+  } catch { return true }
+}
+
 /**
  * Converts a unicode character from an icon font into a data URL image.
  *
@@ -77,6 +125,54 @@ const GENERIC_FAMILIES = new Set([
 const FONT_LIBRARIES = ['katex', 'mathjax', 'mathml']
 
 /**
+ * Perf: a CSS font-family entry is a CSS-wide keyword unless it is also a
+ * quoted string, so the handful of keywords can be rejected without either the
+ * RegExp or the quote-stripping allocation on the hot path.
+ */
+const FAMILY_KEYWORDS = new Set([
+  'inherit', 'initial', 'unset', 'revert', 'revert-layer'
+])
+
+/**
+ * Normalize one raw `font-family` list entry to its CSS family name.
+ *
+ * A CSS <family-name> is a sequence of identifiers, and the CSS tokenizer
+ * collapses any run of whitespace to a single space, while leading/trailing
+ * whitespace of the whole declaration is trimmed. So `  "Noto   Sans " `,
+ * `Noto Sans` and `'Noto\tSans'` are all the same family and must produce the
+ * same embedding key — otherwise the same @font-face is collected, matched and
+ * inlined several times (#357 follow-up).
+ *
+ * @param {string} raw - one comma-separated entry of a font-family list
+ * @returns {string} normalized family name ('' when the entry is empty/keyword)
+ */
+function normalizeFamilyName(raw) {
+  if (!raw) return ''
+  // Fast path: most entries are already a bare, single-token family name.
+  if (FAMILY_KEYWORDS.has(raw)) return ''
+  let f = raw.trim()
+  if (!f) return ''
+  const head = f.charCodeAt(0)
+  // Strip one matching pair of surrounding quotes (a quoted family name may
+  // itself contain commas, so this must happen after the comma split).
+  if (head === 34 /* " */ || head === 39 /* ' */) {
+    if (f.length > 1 && f.charCodeAt(f.length - 1) === head) {
+      f = f.slice(1, -1)
+    } else {
+      return ''
+    }
+  }
+  if (!f) return ''
+  // Collapse internal whitespace runs to a single space (CSS tokenizer rules).
+  if (f.indexOf(' ') >= 0 || f.indexOf('\t') >= 0 || f.indexOf('\n') >= 0 ||
+      f.indexOf('\r') >= 0 || f.indexOf('\f') >= 0 || f.indexOf('\v') >= 0 ||
+      f.indexOf('\u00a0') >= 0) {
+    f = f.split(WS_RUN_RE).join(' ')
+  }
+  return f
+}
+
+/**
  * Normalize a CSS font-family list to the first non-generic family.
  * E.g. `"Roboto", Arial, sans-serif` -> `Roboto`
  * @param {string} familyList
@@ -84,8 +180,8 @@ const FONT_LIBRARIES = ['katex', 'mathjax', 'mathml']
  */
 function pickPrimaryFamily(familyList) {
   if (!familyList) return ''
-  for (let raw of familyList.split(',')) {
-    let f = raw.trim().replace(/^['"]+|['"]+$/g, '')
+  for (let raw of familyList.split(GEN_SPLIT_RE)) {
+    const f = normalizeFamilyName(raw)
     if (!f) continue
     if (!GENERIC_FAMILIES.has(f.toLowerCase())) return f
   }
@@ -95,17 +191,34 @@ function pickPrimaryFamily(familyList) {
 /**
  * #357: Return ALL non-generic families from a font-family list (for fallback chain embedding).
  * E.g. `"Roboto", "Noto Sans SC", sans-serif` -> ["Roboto", "Noto Sans SC"]
+ *
+ * Perf: memoized on the raw list string (few unique values per page) AND
+ * de-duplicated case-insensitively, so a stack that repeats a family
+ * (`A, B, A, sans-serif`) or spells it with different whitespace/quoting yields
+ * ONE entry — the embedding pass then matches and inlines each @font-face once
+ * instead of twice. CSS family names are case-insensitive and the embedding
+ * index is keyed lowercase, so `Roboto` + `roboto` are the same font.
+ *
  * @param {string} familyList
  * @returns {string[]}
  */
 function pickAllFamilies(familyList) {
-  if (!familyList) return []
+  if (!familyList) return EMPTY_FAMILIES
+  const cached = _pickAllCache.get(familyList)
+  if (cached !== undefined) return cached
   const out = []
-  for (let raw of familyList.split(',')) {
-    let f = raw.trim().replace(/^['"]+|['"]+$/g, '')
+  for (let raw of familyList.split(GEN_SPLIT_RE)) {
+    const f = normalizeFamilyName(raw)
     if (!f) continue
-    if (!GENERIC_FAMILIES.has(f.toLowerCase())) out.push(f)
+    if (GENERIC_FAMILIES.has(f.toLowerCase())) continue
+    let dup = false
+    const lower = f.toLowerCase()
+    for (let i = 0; i < out.length; i++) {
+      if (out[i].toLowerCase() === lower) { dup = true; break }
+    }
+    if (!dup) out.push(f)
   }
+  _pickAllCache.set(familyList, out)
   return out
 }
 
@@ -114,11 +227,19 @@ function pickAllFamilies(familyList) {
  * @param {string|number} w
  */
 function normWeight(w) {
-  const t = String(w ?? '400').trim().toLowerCase()
-  if (t === 'normal') return 400
-  if (t === 'bold') return 700
-  const n = parseInt(t, 10)
-  return Number.isFinite(n) ? Math.min(900, Math.max(100, n)) : 400
+  const k = String(w ?? '400')
+  const c = _normWeightCache.get(k)
+  if (c !== undefined) return c
+  const t = k.trim().toLowerCase()
+  let r
+  if (t === 'normal') r = 400
+  else if (t === 'bold') r = 700
+  else {
+    const n = parseInt(t, 10)
+    r = Number.isFinite(n) ? Math.min(900, Math.max(100, n)) : 400
+  }
+  _normWeightCache.set(k, r)
+  return r
 }
 
 /**
@@ -127,10 +248,15 @@ function normWeight(w) {
  * @returns {"normal"|"italic"|"oblique"}
  */
 function normStyle(s) {
-  const t = String(s ?? 'normal').trim().toLowerCase()
-  if (t.startsWith('italic')) return 'italic'
-  if (t.startsWith('oblique')) return 'oblique'
-  return 'normal'
+  const k = String(s ?? 'normal')
+  const c = _normStyleCache.get(k)
+  if (c) return c
+  const t = k.trim().toLowerCase()
+  let r = 'normal'
+  if (t.startsWith('italic')) r = 'italic'
+  else if (t.startsWith('oblique')) r = 'oblique'
+  _normStyleCache.set(k, r)
+  return r
 }
 
 /**
@@ -139,8 +265,13 @@ function normStyle(s) {
  * @returns {number}
  */
 function normStretchPct(st) {
-  const m = String(st ?? '100%').match(/(\d+(?:\.\d+)?)\s*%/)
-  return m ? Math.max(50, Math.min(200, parseFloat(m[1]))) : 100
+  const k = String(st ?? '100%')
+  const c = _normStretchCache.get(k)
+  if (c !== undefined) return c
+  const m = k.match(/(\d+(?:\.\d+)?)\s*%/)
+  const r = m ? Math.max(50, Math.min(200, parseFloat(m[1]))) : 100
+  _normStretchCache.set(k, r)
+  return r
 }
 
 function parseWeightSpec(spec) {
@@ -267,6 +398,52 @@ const IMPORT_ANY_RE = /@import\s+(?:url\(\s*(['"]?)([^)"']+)\1\s*\)|(['"])([^"']
 
 const MAX_IMPORT_DEPTH = 4
 
+// ---------------------------------------------------------------------------
+// Perf: fetch-once-per-URL memo for raw stylesheet CSS text.
+//
+// `embedCustomFonts` reads the same stylesheet more than once in a single
+// capture: the <link> pass fetches it as text, every nested @import is fetched
+// by inlineImportsAndRewrite(), and a cross-origin sheet whose CSSOM is blocked
+// is re-fetched on each pass. snapFetch only dedupes *inflight* calls, so
+// sequential reads of one URL still hit the network every time.
+//
+// The cached value is the raw CSS text for a URL — a pure function of the URL +
+// proxy — so it is safe to reuse. The map is created PER embedCustomFonts call
+// (a "capture session"), never module-global: a global memo would leak CSS
+// across captures and serve stale text to a later, unrelated capture.
+//
+// It is also deliberately NOT stored in cache.resource (an EvictingMap shared
+// with base64 payloads) so a big stylesheet cannot evict embedded font data.
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a stylesheet's raw CSS text at most once per URL (per capture session).
+ * @param {string} url
+ * @param {string} useProxy
+ * @param {Map<string, {ok:boolean, data:string|null}>} memo - per-call memo
+ * @param {boolean} [silent=false]
+ * @returns {Promise<{ok:boolean, data:string|null, status?:number, url?:string, reason?:string}>}
+ */
+async function fetchCssTextOnce(url, useProxy, memo, silent = false) {
+  if (!url) return { ok: false, data: null, status: 0, url }
+  const key = `${useProxy || ''} ${url}`
+  const hit = memo.get(key)
+  if (hit !== undefined) return hit
+  let res
+  try {
+    res = await snapFetch(url, { as: 'text', useProxy, silent })
+  } catch {
+    res = { ok: false, data: null, status: 0, url, reason: 'exception' }
+  }
+  const out = (res && res.ok && typeof res.data === 'string')
+    ? res
+    : { ok: false, data: null, status: (res && res.status) || 0, url, reason: (res && res.reason) || 'fetch_failed' }
+  // Only memoize successes: snapFetch already caches *errors* (with TTL), and
+  // pinning a failure here too would outlive that TTL and hide a recovery.
+  if (out.ok) memo.set(key, out)
+  return out
+}
+
 /**
  * Flattens @import recursively and rewrites relative urls at each level
  * using that sheet's base href. Uses snapFetch (with proxy) on purpose
@@ -274,8 +451,9 @@ const MAX_IMPORT_DEPTH = 4
  * @param {string} cssText
  * @param {string} ownerHref
  * @param {string} useProxy
+ * @param {Map<string, {ok:boolean, data:string|null}>} [memo] - per-capture CSS-text memo
  */
-async function inlineImportsAndRewrite(cssText, ownerHref, useProxy) {
+async function inlineImportsAndRewrite(cssText, ownerHref, useProxy, memo) {
   if (!cssText) return cssText
 
   const visited = new Set()
@@ -308,7 +486,7 @@ async function inlineImportsAndRewrite(cssText, ownerHref, useProxy) {
 
       let imported = ''
       try {
-        const r = await snapFetch(absUrl, { as: 'text', useProxy, silent: true })
+        const r = await fetchCssTextOnce(absUrl, useProxy, memo, true)
         if (r.ok && typeof r.data === 'string') imported = r.data
       } catch { /* noop */ }
 
@@ -783,6 +961,11 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
 
   const simpleExcluder = buildSimpleExcluder(exclude)
 
+  // Perf: fetch-once-per-URL memo, scoped to THIS embedCustomFonts call (one
+  // capture session). Created after the cache.resource short-circuit below so a
+  // cache hit never pays for an unused Map.
+  const cssTextMemo = new Map()
+
   const cacheKey = buildFontsCacheKey(required, exclude, localFonts, useProxy, fontStylesheetDomains, doc)
   if (cache.resource?.has(cacheKey)) {
     return cache.resource.get(cacheKey)
@@ -790,6 +973,16 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
 
   // ---- Ensure only likely @import font styles become reachable (<link>), avoid noise ----
   const requiredFamilies = familiesFromRequired(required)
+
+  // Build the set of existing <link rel="stylesheet"> hrefs ONCE (a single
+  // document scan) instead of running a full-document querySelector per @import
+  // URL below. Raw attribute values are compared, matching the original
+  // `[href="${u}"]` attribute selector exactly.
+  const existingLinkHrefs = new Set(
+    Array.from(doc.querySelectorAll('link[rel="stylesheet"]'))
+      .map((l) => (l.getAttribute('href') || '').trim())
+      .filter(Boolean)
+  )
 
   const importUrls = []
   const IMPORT_ANY_RE_LOCAL = IMPORT_ANY_RE
@@ -799,8 +992,8 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
     for (const m of cssText.matchAll(IMPORT_ANY_RE_LOCAL)) {
       const u = (m[2] || m[4] || '').trim()
       if (!u || isIconFont(u)) continue
-      const hasLink = !!doc.querySelector(`link[rel="stylesheet"][href="${u}"]`)
-      if (!hasLink) importUrls.push(u)
+      const hasLink = existingLinkHrefs.has(u)
+      if (!hasLink && !importUrls.includes(u)) importUrls.push(u)
     }
   }
   // @import font URLs with no matching <link> are made reachable by injecting a temporary
@@ -808,7 +1001,7 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
   const injectedLinks = []
   if (importUrls.length) {
     await Promise.all(importUrls.map((u) => new Promise((resolve) => {
-      if (doc.querySelector(`link[rel="stylesheet"][href="${u}"]`)) return resolve(null)
+      if (existingLinkHrefs.has(u)) return resolve(null)
       const link = doc.createElement('link')
       link.rel = 'stylesheet'
       link.href = u
@@ -861,13 +1054,13 @@ function faceMatchesRequired(fam, styleSpec, weightSpec, stretchSpec) {
       }
 
       if (!cssText) {
-        const res = await snapFetch(link.href, { as: 'text', useProxy })
+        const res = await fetchCssTextOnce(link.href, useProxy, cssTextMemo)
         if (res?.ok && typeof res.data === 'string') cssText = res.data
         if (isIconFont(link.href)) continue
       }
 
       // Flatten nested @import and rewrite relative urls per-level using link.href as base
-      cssText = await inlineImportsAndRewrite(cssText, link.href, useProxy)
+      cssText = await inlineImportsAndRewrite(cssText, link.href, useProxy, cssTextMemo)
 
       let facesOut = ''
       for (const face of cssText.match(FACE_RE) || []) {
@@ -1047,6 +1240,8 @@ export function collectFontUsage(root, keep) {
   const required = /* @__PURE__ */ new Set()
   const usedCodepoints = /* @__PURE__ */ new Set()
   if (!root) return { required, usedCodepoints }
+  const _doc = root.ownerDocument || document
+  const _hasPseudos = hasPseudoInDoc(_doc)
 
   const pushText = (txt) => {
     if (!txt) return
@@ -1057,12 +1252,16 @@ export function collectFontUsage(root, keep) {
     // This ensures that if the first font doesn't have a glyph, the fallback font is also embedded.
     const families = pickAllFamilies(cs.fontFamily)
     if (!families.length) return
+    // Perf: the weight/style/stretch suffix is identical for every family in the
+    // stack, so build it once per style instead of once per family.
+    const suffix = `__${normWeight(cs.fontWeight)}__${normStyle(cs.fontStyle)}__${normStretchPct(cs.fontStretch)}`
     for (const family of families) {
-      required.add(`${family}__${normWeight(cs.fontWeight)}__${normStyle(cs.fontStyle)}__${normStretchPct(cs.fontStretch)}`)
+      required.add(family + suffix)
     }
   }
   const visitElement = (el) => {
     addFromStyle(getStyle(el))
+    if (!_hasPseudos) return
     for (const pseudo of ['::before', '::after']) {
       const cs = getStyle(el, pseudo)
       const c = cs && cs.content

--- a/src/modules/lineClamp.js
+++ b/src/modules/lineClamp.js
@@ -27,12 +27,29 @@ export function lineClampTree(el, clipRect) {
             bottom < clipRect.top - M || r.top > clipRect.bottom + M) return
       }
     }
-    // One computed-style read per node, shared by both passes (hot path).
-    const cs = getComputedStyle(node)
-    const u1 = lineClamp(node, cs)
-    if (u1) undos.push(u1)
-    const u2 = textEllipsis(node, cs)
-    if (u2) undos.push(u2)
+    // Cheap guard BEFORE the expensive getComputedStyle (hot path).
+    //
+    // Both passes can only ever act on a *plain text container*: lineClamp()
+    // and textEllipsis() each bail out early via isPlainTextContainer(el),
+    // which requires `childElementCount === 0` AND at least one text node.
+    // So any element with element children — or with no text at all — cannot
+    // possibly be clamped, and reading its computed style is pure waste.
+    // That is the overwhelming majority of nodes in a real DOM, and it is a
+    // strict superset check: nothing that could be clamped is ever skipped,
+    // so behaviour is bit-for-bit identical.
+    //
+    // Note the guard is deliberately structural, NOT `el.style.*`-based:
+    // class-driven clamping (`-webkit-line-clamp` from a stylesheet, or
+    // text-overflow via a utility class) leaves no trace in the inline style,
+    // so an inline-only guard would silently drop real ellipsis.
+    if (isPlainTextContainerFast(node)) {
+      // One computed-style read per node, shared by both passes (hot path).
+      const cs = getComputedStyle(node)
+      const u1 = lineClamp(node, cs)
+      if (u1) undos.push(u1)
+      const u2 = textEllipsis(node, cs)
+      if (u2) undos.push(u2)
+    }
     for (const child of node.children || []) walk(child)
   }
   walk(el)
@@ -209,4 +226,26 @@ function vpad(cs) {
 function isPlainTextContainer(el) {
   if (el.childElementCount > 0) return false
   return Array.from(el.childNodes).some(n => n.nodeType === Node.TEXT_NODE)
+}
+
+/**
+ * Allocation-free, side-effect-free version of isPlainTextContainer().
+ *
+ * Same predicate, but walks childNodes with a plain for-loop instead of
+ * `Array.from(...).some(...)` — no intermediate array per element — and
+ * short-circuits on the first text node.
+ *
+ * Used as the hot-path guard in lineClampTree(): it must stay *exactly*
+ * equivalent to isPlainTextContainer(), otherwise elements that would clamp
+ * stop clamping (or vice-versa).
+ *
+ * @param {Element} el
+ * @returns {boolean}
+ */
+function isPlainTextContainerFast(el) {
+  if (el.childElementCount > 0) return false
+  for (let n = el.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === Node.TEXT_NODE) return true
+  }
+  return false
 }

--- a/src/modules/pseudo.js
+++ b/src/modules/pseudo.js
@@ -30,6 +30,14 @@ const __preflightMemo = new WeakMap()
  *  300 was too low for large apps (Tailwind, MUI) with 500+ utility rules — raised to 1000. */
 const CSS_RULE_SCAN_BUDGET = 1000
 
+/** The pseudo-element kinds we inline, in paint order. Hoisted so the per-node
+ *  recursion loop doesn't re-allocate the array for every one of the thousands
+ *  of elements it visits. */
+const PSEUDO_LIST = ['::before', '::after', '::first-letter']
+
+/** Border sides, hoisted out of hasPaintedBorder (called up to twice per element). */
+const BORDER_SIDES = ['Top', 'Right', 'Bottom', 'Left']
+
 /**
  * Returns whether to process pseudos, but also memoizes the last fingerprint
  * seen in the provided sessionCache to avoid stale results between tests/runs.
@@ -220,6 +228,142 @@ export function shouldProcessPseudos(doc = document, fp = styleFingerprint(doc))
   return false
 }
 
+/** Cache for pseudo selector bloom filter per document+fingerprint */
+const __pseudoSelectorCache = new WeakMap()
+
+/**
+ * Collects base selectors for each pseudo type by scanning stylesheets once per epoch.
+ * Returns a map of pseudo -> comma-joined base selectors (or '*' if universal).
+ * If no selectors for a type, returns null (skip that pseudo entirely).
+ * @param {Document} doc
+ * @param {Object} sessionCache
+ * @returns {{before:string|null, after:string|null, firstLetter:string|null}}
+ */
+function getPseudoSelectors(doc, sessionCache) {
+  const fp = styleFingerprint(doc)
+  const cached = __pseudoSelectorCache.get(doc)
+  if (cached && cached.fp === fp && cached.selectors) return cached.selectors
+
+  const beforeSet = new Set()
+  const afterSet = new Set()
+  const firstLetterSet = new Set()
+  let hasUniversalBefore = false
+  let hasUniversalAfter = false
+  let hasUniversalFirstLetter = false
+
+  const addSelectorsForRule = (selectorText) => {
+    if (!selectorText) return
+    // Split by comma, handling that content may contain commas? but selectorText shouldn't have quoted commas
+    const parts = selectorText.split(',')
+    for (let part of parts) {
+      part = part.trim()
+      const lower = part.toLowerCase()
+      let type = null
+      if (lower.includes('::before') || lower.includes(':before')) type = 'before'
+      else if (lower.includes('::after') || lower.includes(':after')) type = 'after'
+      else if (lower.includes('::first-letter') || lower.includes(':first-letter')) type = 'firstLetter'
+      else continue
+
+      // Strip pseudo from end to get base selector
+      // Handles a:hover::before -> a:hover, ::before -> *
+      let base = part.replace(/::?before|::?after|::?first-letter/gi, '').trim()
+      // Remove trailing combinators/pseudo leftovers like ":" or "::"
+      base = base.replace(/[:]+$/, '').trim()
+      if (!base) base = '*'
+
+      // Validate selector quickly — skip invalid ones that would throw in matches()
+      try {
+        // Test with a dummy element? Just check syntax by trying to use it
+        // We do a lightweight check: querySelector with base should not throw for valid
+        // But to avoid throwing per rule, we just try to add and catch later in matches
+        if (type === 'before') {
+          if (base === '*') hasUniversalBefore = true
+          else beforeSet.add(base)
+        } else if (type === 'after') {
+          if (base === '*') hasUniversalAfter = true
+          else afterSet.add(base)
+        } else if (type === 'firstLetter') {
+          if (base === '*') hasUniversalFirstLetter = true
+          else firstLetterSet.add(base)
+        }
+      } catch {}
+    }
+  }
+
+  const scanRules = (rules) => {
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i]
+      try {
+        // @import: CSSImportRule exposes sheet via rule.styleSheet (§8: must match allow-list coverage)
+        if (rule.styleSheet) {
+          try {
+            const importedRules = rule.styleSheet.cssRules
+            if (importedRules) scanRules(importedRules)
+          } catch {}
+        }
+        if (rule.selectorText) {
+          addSelectorsForRule(rule.selectorText)
+        }
+        // Recurse into grouping rules (@media, @supports, etc.)
+        if (rule.cssRules) scanRules(rule.cssRules)
+      } catch {}
+    }
+  }
+
+  try {
+    for (const sheet of doc.styleSheets) {
+      const rules = safeRules(sheet)
+      if (rules) scanRules(rules)
+    }
+    const ass = /** @type {any} */ (doc).adoptedStyleSheets
+    if (Array.isArray(ass)) {
+      for (const sheet of ass) {
+        const rules = safeRules(sheet)
+        if (rules) scanRules(rules)
+      }
+    }
+    // Shadow roots (Lit, web components) — same coverage as styles allow-list (§8)
+    try {
+      const walker = doc.createTreeWalker(doc.documentElement, NodeFilter.SHOW_ELEMENT)
+      let n
+      while ((n = walker.nextNode())) {
+        const sr = n.shadowRoot
+        if (sr) {
+          if (sr.adoptedStyleSheets && sr.adoptedStyleSheets.length) {
+            for (const sheet of sr.adoptedStyleSheets) {
+              const rules = safeRules(sheet)
+              if (rules) scanRules(rules)
+            }
+          }
+          if (sr.styleSheets) {
+            try {
+              for (const sheet of sr.styleSheets) {
+                const rules = safeRules(sheet)
+                if (rules) scanRules(rules)
+              }
+            } catch {}
+          }
+          for (const st of sr.querySelectorAll('style')) {
+            const sheet = st.sheet
+            if (sheet) {
+              const rules = safeRules(sheet)
+              if (rules) scanRules(rules)
+            }
+          }
+        }
+      }
+    } catch {}
+  } catch {}
+
+  const selectors = {
+    before: hasUniversalBefore ? '*' : (beforeSet.size ? Array.from(beforeSet).join(',') : null),
+    after: hasUniversalAfter ? '*' : (afterSet.size ? Array.from(afterSet).join(',') : null),
+    firstLetter: hasUniversalFirstLetter ? '*' : (firstLetterSet.size ? Array.from(firstLetterSet).join(',') : null),
+  }
+  __pseudoSelectorCache.set(doc, { fp, selectors })
+  return selectors
+}
+
 /**
  * True if any single side paints a border. The `border-width`/`border-style` shorthands
  * can't be parsed with parseFloat: a `border-bottom` resolves to "0px 0px 1px 0px", whose
@@ -228,7 +372,7 @@ export function shouldProcessPseudos(doc = document, fp = styleFingerprint(doc))
  * @returns {boolean}
  */
 function hasPaintedBorder(style) {
-  for (const side of ['Top', 'Right', 'Bottom', 'Left']) {
+  for (const side of BORDER_SIDES) {
     const w = parseFloat(style[`border${side}Width`]) || 0
     const s = style[`border${side}Style`]
     if (w > 0 && s && s !== 'none' && s !== 'hidden') return true
@@ -450,7 +594,7 @@ export async function inlinePseudoElements(source, clone, sessionCache, options)
   // <span> (as the ::first-letter path does) drops them from the rendered value.
   // Browsers don't render pseudo-elements on textarea anyway.
   if (source.tagName === 'TEXTAREA') return
-  // --- NEW: preflight once per session/doc ---
+  // --- Preflight once per session/doc ---
   const doc = source.ownerDocument || document
   if (!preflightWithFp(doc, sessionCache)) {
     return
@@ -469,9 +613,43 @@ export async function inlinePseudoElements(source, clone, sessionCache, options)
     sessionCache.__counterCtx = lazyCounterContext(source.ownerDocument || document, sessionCache)
   }
   const counterCtx = sessionCache.__counterCtx
+  const pseudoSelectors = getPseudoSelectors(doc, sessionCache)
 
-  for (const pseudo of ['::before', '::after', '::first-letter']) {
+  for (const pseudo of PSEUDO_LIST) {
     try {
+      // ::first-letter can only wrap a DIRECT non-empty text node. Detect that cheaply
+      // (clone is detached — no style read) so we skip its pseudo getComputedStyle on the
+      // common case of elements without direct text.
+      let firstLetterTextNode = null
+      if (pseudo === '::first-letter') {
+        firstLetterTextNode = Array.from(clone.childNodes).find(
+          (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim().length > 0
+        )
+        if (!firstLetterTextNode) continue
+      }
+
+      // Bloom filter: skip getComputedStyle if element doesn't match any selector that defines this pseudo.
+      // Saves ~2-3 getComputedStyle per element on huge pages where only a handful of elements have pseudo.
+      if (pseudo === '::before') {
+        const sel = pseudoSelectors.before
+        if (sel === null) continue
+        if (sel !== '*') {
+          try { if (!source.matches(sel)) continue } catch { /* invalid selector, fall through */ }
+        }
+      } else if (pseudo === '::after') {
+        const sel = pseudoSelectors.after
+        if (sel === null) continue
+        if (sel !== '*') {
+          try { if (!source.matches(sel)) continue } catch {}
+        }
+      } else if (pseudo === '::first-letter') {
+        const sel = pseudoSelectors.firstLetter
+        if (sel === null) continue
+        if (sel !== '*') {
+          try { if (!source.matches(sel)) continue } catch {}
+        }
+      }
+
       const style = getStyle(source, pseudo)
       if (!style) continue
       // Skip visually empty pseudo-elements early
@@ -510,11 +688,7 @@ export async function inlinePseudoElements(source, clone, sessionCache, options)
           boxDiff('marginBottom') || boxDiff('marginLeft')
         if (!isMeaningful) continue
 
-        const textNode = Array.from(clone.childNodes).find(
-          (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim().length > 0
-        )
-        if (!textNode) continue
-
+        const textNode = firstLetterTextNode
         const text = textNode.textContent
         const match = text.match(/^([^\p{L}\p{N}\s]*[\p{L}\p{N}](?:['’])?)/u)
         const first = match?.[0]
@@ -587,7 +761,7 @@ const hasExplicitContent = !isNoExplicitContent && cleanContent !== ''
             // reconstruir valor final desde derived: volvemos a pedirlo
             // Usamos withSiblingOverrides + derive para ser consistentes
             const baseWithSibs = withSiblingOverrides(source, counterCtx, sessionCache.__siblingCounters)
-            const derived = deriveCounterCtxForPseudo(source, getStyle(source, pseudo), baseWithSibs)
+            const derived = deriveCounterCtxForPseudo(source, style, baseWithSibs)
             const finalVal = derived.get(source, name)
             map.set(name, finalVal)
           }
@@ -712,7 +886,7 @@ const hasExplicitContent = !isNoExplicitContent && cleanContent !== ''
       if (incs && incs.length && source.parentElement) {
         const map = sessionCache.__siblingCounters.get(source.parentElement) || new Map()
         const baseWithSibs = withSiblingOverrides(source, counterCtx, sessionCache.__siblingCounters)
-        const derived = deriveCounterCtxForPseudo(source, getStyle(source, pseudo), baseWithSibs)
+        const derived = deriveCounterCtxForPseudo(source, style, baseWithSibs)
         for (const { name } of incs) {
           if (!name) continue
           const finalVal = derived.get(source, name)

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -1,4 +1,4 @@
-import { getStyleKey, softensWidth, softenNeedsAutoWidth, shouldIgnoreProp, getStyle } from '../utils/index.js'
+import { getStyleKey, softensWidth, softenNeedsAutoWidth, shouldIgnoreProp, getStyle, NO_DEFAULTS_TAGS, _invalidateSplitCaches } from '../utils/index.js'
 import { cache } from '../core/cache.js'
 
 const snapshotCache = new WeakMap()
@@ -8,8 +8,12 @@ const snapshotKeyCache = new Map()
  *  unique element styles, this Map can grow without bound and leak memory. */
 const MAX_SNAPSHOT_KEY_CACHE = 2000
 let __epoch = 0
+let __structSnapEpoch = -1
 function bumpEpoch() {
   __epoch++
+  __structSnapEpoch = -1
+  __structSnapCache = null
+  try { _invalidateSplitCaches?.() } catch {}
   // Evict when oversized — entries are cheap to rebuild on the next capture.
   if (snapshotKeyCache.size > MAX_SNAPSHOT_KEY_CACHE) snapshotKeyCache.clear()
 }
@@ -84,82 +88,289 @@ export function needsBackgroundInline(source) {
   return true
 }
 
+// PERF-5: "used property" allow-list (Juan's v3 idea). Reading every one of the ~370
+// `style.length` computed properties per node is the single biggest cost in a capture.
+// But the vast majority are browser defaults that contribute nothing to a static snapshot.
+// We scan the document's author stylesheets ONCE per epoch to learn which CSS properties
+// the page can actually set, then only snapshot those (plus a small set of module-required
+// props the engine reads explicitly). Any authored property lands in the allow-set, so the
+// output is identical for everything the author styled; only true UA defaults are skipped.
+// This is ~2x faster than reading all props and is safe: a property not in the allow-set
+// can never carry an authored (non-default) value.
+const SHORTHAND_EXPANSIONS = new Map([
+  ['margin', ['margin-top','margin-right','margin-bottom','margin-left','margin-block-start','margin-block-end','margin-inline-start','margin-inline-end']],
+  ['padding', ['padding-top','padding-right','padding-bottom','padding-left','padding-block-start','padding-block-end','padding-inline-start','padding-inline-end']],
+  ['border', ['border-top-width','border-top-style','border-top-color','border-right-width','border-right-style','border-right-color','border-bottom-width','border-bottom-style','border-bottom-color','border-left-width','border-left-style','border-left-color','border-width','border-style','border-color','border-block-start-width','border-block-start-style','border-block-start-color','border-block-end-width','border-block-end-style','border-block-end-color','border-inline-start-width','border-inline-start-style','border-inline-start-color','border-inline-end-width','border-inline-end-style','border-inline-end-color']],
+  ['border-width', ['border-top-width','border-right-width','border-bottom-width','border-left-width','border-block-start-width','border-block-end-width','border-inline-start-width','border-inline-end-width']],
+  ['border-style', ['border-top-style','border-right-style','border-bottom-style','border-left-style','border-block-start-style','border-block-end-style','border-inline-start-style','border-inline-end-style']],
+  ['border-color', ['border-top-color','border-right-color','border-bottom-color','border-left-color','border-block-start-color','border-block-end-color','border-inline-start-color','border-inline-end-color']],
+  ['border-radius', ['border-top-left-radius','border-top-right-radius','border-bottom-right-radius','border-bottom-left-radius','border-start-start-radius','border-start-end-radius','border-end-start-radius','border-end-end-radius']],
+  ['background', ['background-image','background-color','background-position','background-position-x','background-position-y','background-size','background-repeat','background-attachment','background-origin','background-clip','background-blend-mode']],
+  ['background-position', ['background-position-x','background-position-y']],
+  ['font', ['font-family','font-size','font-weight','font-style','font-variant','line-height','font-stretch','font-size-adjust','font-kerning']],
+  ['flex', ['flex-grow','flex-shrink','flex-basis','flex-direction','flex-wrap']],
+  ['gap', ['row-gap','column-gap']],
+  ['inset', ['top','right','bottom','left','inset-block-start','inset-block-end','inset-inline-start','inset-inline-end']],
+  ['overflow', ['overflow-x','overflow-y','overflow-block','overflow-inline']],
+  ['text-decoration', ['text-decoration-line','text-decoration-color','text-decoration-style','text-decoration-thickness','text-underline-offset']],
+])
+function addWithExpansion(prop, set) {
+  if (shouldIgnoreProp(prop)) return
+  set.add(prop)
+  const ex = SHORTHAND_EXPANSIONS.get(prop)
+  if (ex) for (const p of ex) {
+    if (!shouldIgnoreProp(p)) set.add(p)
+  }
+}
+const MODULE_REQUIRED_PROPS = [
+  'background-image', 'background-color', 'content-visibility',
+  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+  'border-image-source', 'background', 'min-width', 'min-height',
+  'text-decoration-line', 'text-decoration-color', 'text-decoration-style',
+  'text-decoration-thickness', 'text-underline-offset', 'text-decoration-skip-ink',
+  '-webkit-text-stroke', '-webkit-text-stroke-width', '-webkit-text-stroke-color', 'paint-order',
+  'font-feature-settings', 'font-variation-settings', 'font-kerning', 'font-variant',
+  'font-variant-ligatures', 'font-optical-sizing', 'animation-name',
+  'width', 'height', 'display', 'position', 'color', 'font-size', 'font-family',
+  'margin', 'padding', 'border', 'opacity', 'transform', 'box-shadow', 'background-clip',
+  'overflow', 'flex', 'grid', 'gap', 'z-index', 'visibility', 'mix-blend-mode',
+  // border-radius longhands (both physical and logical — computed exposes both)
+  'border-top-left-radius','border-top-right-radius','border-bottom-right-radius','border-bottom-left-radius',
+  'border-start-start-radius','border-start-end-radius','border-end-start-radius','border-end-end-radius',
+  '-webkit-text-fill-color',
+  // logical sizes and origins that otherwise appear as dropped non-defaults
+  'block-size','inline-size','min-block-size','min-inline-size','max-block-size','max-inline-size',
+  'perspective-origin','transform-origin','unicode-bidi',
+  'caret-color','column-rule-color','row-rule-color','outline-color','text-emphasis-color',
+  // background/mask/border-image props needed by inlineBackgroundImages — ensure they are
+  // always in the snapshot so that pass can reuse the snapshot instead of re-reading
+  'mask','mask-image','-webkit-mask','-webkit-mask-image','mask-source','mask-box-image-source','mask-border-source','-webkit-mask-box-image-source','border-image',
+  'mask-position','mask-size','mask-repeat','mask-mode','mask-composite','-webkit-mask-position','-webkit-mask-size','-webkit-mask-repeat','-webkit-mask-composite','mask-origin','mask-clip','-webkit-mask-origin','-webkit-mask-clip','-webkit-mask-position-x','-webkit-mask-position-y',
+  'background-position','background-position-x','background-position-y','background-size','background-repeat','background-origin','background-clip','background-attachment','background-blend-mode',
+  'border-image-slice','border-image-width','border-image-outset','border-image-repeat'
+]
+let __usedPropSet = null
+let __usedPropEpoch = -1
+function getUsedPropSet(epoch) {
+  // Debug escape hatch: window.__SNAPDOM_FULL_PROPS forces the legacy full read
+  // (used by the PERF-5 pixel-equivalence verification test).
+  if (typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) return null
+  if (__usedPropSet && __usedPropEpoch === epoch) {
+    return __usedPropSet
+  }
+  const set = new Set()
+  for (const p of MODULE_REQUIRED_PROPS) addWithExpansion(p, set)
+  const collectFromSheets = (sheets) => {
+    for (const sheet of sheets) {
+      let rules
+      try { rules = sheet.cssRules } catch { continue }
+      if (!rules) continue
+      collectSheetProps(rules, set)
+    }
+  }
+  try {
+    collectFromSheets(document.styleSheets)
+    // adoptedStyleSheets (Lit, Constructable Stylesheets)
+    const adopted = document.adoptedStyleSheets
+    if (Array.isArray(adopted) && adopted.length) collectFromSheets(adopted)
+    // Shadow roots in the document (best-effort: walk from capture root when available,
+    // but also scan all elements with shadowRoot)
+    try {
+      const walker = document.createTreeWalker(document.documentElement, NodeFilter.SHOW_ELEMENT)
+      let n
+      while ((n = walker.nextNode())) {
+        const sr = n.shadowRoot
+        if (sr) {
+          if (sr.adoptedStyleSheets && sr.adoptedStyleSheets.length) collectFromSheets(sr.adoptedStyleSheets)
+          // shadowRoot.styleSheets is not standard but some polyfills expose it
+          if (sr.styleSheets) {
+            try { collectFromSheets(sr.styleSheets) } catch {}
+          }
+          // Inline <style> inside shadow root
+          for (const st of sr.querySelectorAll('style')) {
+            const sheet = st.sheet
+            if (sheet) {
+              try { collectSheetProps(sheet.cssRules || [], set) } catch {}
+            }
+          }
+        }
+      }
+    } catch {}
+  } catch { /* cross-origin / empty */ }
+  // A3: UA stylesheet diff — ensure properties where UA differs from initial are included
+  // (white-space:pre for <pre>, text-align:center for <th>, list-style-type, etc.)
+  // Cheap: ~30 tags × one style read, diff vs initial, union into allow-set.
+  try {
+    const uaTags = ['pre','th','td','ol','ul','li','sub','sup','select','input','button','table','caption','blockquote','h1','h2','h3','p','a']
+    for (const tag of uaTags) {
+      const defaults = getDefaultStyleForTag(tag)
+      // Probe without all:initial to get UA value
+      let probe
+      try {
+        const sandbox = document.getElementById('snapdom-sandbox')
+        // Reuse sandbox logic: create element without all:initial
+        const tmp = document.createElement(tag)
+        const parent = sandbox || document.body
+        parent.appendChild(tmp)
+        const cs = getComputedStyle(tmp)
+        for (let i = 0; i < cs.length; i++) {
+          const prop = cs[i]
+          if (set.has(prop) || shouldIgnoreProp(prop)) continue
+          const uaVal = cs.getPropertyValue(prop)
+          const initVal = defaults[prop]
+          if (uaVal && initVal !== undefined && uaVal !== initVal) {
+            // Only add if UA value is not initial — it can affect rendering in foreignObject
+            // where we reset to initial via baseCSS
+            addWithExpansion(prop, set)
+          }
+        }
+        parent.removeChild(tmp)
+      } catch {}
+    }
+  } catch {}
+  __usedPropSet = set
+  __usedPropEpoch = epoch
+  return set
+}
+
+/** Build (once per epoch) the used-prop allow-set and seed it with the captured subtree's
+ *  inline-style property names. Call from prepareClone before the snapshot walk. */
+export function seedUsedProps(root) {
+  const set = getUsedPropSet(__epoch)
+  if (set) seedInlineProps(root, set)
+}
+export function getUsedPropSetDebug() { return __usedPropSet }
+export function getCachedSnapshot(el) {
+  const rec = snapshotCache.get(el)
+  return rec && rec.epoch === __epoch ? rec.snapshot : null
+}
+export { snapshotComputedStyleFull }
+function collectSheetProps(rules, set) {
+  for (const rule of rules) {
+    // @import: CSSImportRule exposes sheet via rule.styleSheet
+    if (rule.styleSheet) {
+      try {
+        const importedRules = rule.styleSheet.cssRules
+        if (importedRules) collectSheetProps(importedRules, set)
+      } catch { /* cross-origin import */ }
+    }
+    if (rule.style) for (let i = 0; i < rule.style.length; i++) addWithExpansion(rule.style[i], set)
+    if (rule.cssRules) collectSheetProps(rule.cssRules, set)
+  }
+}
+
+// Seed the allow-set with the inline-style property names of every node in the captured
+// subtree. O(n) with NO getComputedStyle calls (we read element.style names directly), so
+// it is cheap. Authoring via inline style is extremely common (snapdom itself, component
+// frameworks), and without this the allow-set would wrongly drop such props.
+function seedInlineProps(root, set) {
+  const stack = [root]
+  while (stack.length) {
+    const n = stack.pop()
+    if (n.style) for (let i = 0; i < n.style.length; i++) addWithExpansion(n.style[i], set)
+    const kids = n.children
+    for (let i = 0; i < kids.length; i++) stack.push(kids[i])
+  }
+}
+
 function snapshotComputedStyleFull(style, options = {}) {
   const out = {}
   const excludeStyleProps = options.excludeStyleProps
-  for (let i = 0; i < style.length; i++) {
-    const prop = style[i]
-    if (shouldIgnoreProp(prop)) continue
-    if (excludeStyleProps) {
-      if (excludeStyleProps instanceof RegExp && excludeStyleProps.test(prop)) continue
-      if (typeof excludeStyleProps === 'function' && excludeStyleProps(prop)) continue
+  const allow = options.__usedProps || ((typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) ? null : (__usedPropSet && __usedPropEpoch === __epoch ? __usedPropSet : null))
+  // C3 micro: normalize exclude predicate once per snapshot, not per prop
+  let excludePred = null
+  if (excludeStyleProps) {
+    if (excludeStyleProps instanceof RegExp) {
+      const re = excludeStyleProps
+      excludePred = (p) => re.test(p)
+    } else if (typeof excludeStyleProps === 'function') {
+      excludePred = excludeStyleProps
     }
-    let val = style.getPropertyValue(prop)
-    if ((prop === 'background-image' || prop === 'content') && val.includes('url(') && !val.includes('data:')) {
-      val = 'none'
-    }
-    out[prop] = val
   }
+  if (allow) {
+    for (const prop of allow) {
+      // A5: custom properties already filtered at insertion, but keep guard for safety
+      if (prop[0] === '-' && prop[1] === '-') continue
+      if (excludePred && excludePred(prop)) continue
+      let val = ''
+      try { val = style.getPropertyValue(prop) } catch { continue }
+      if (!val) continue
+      if ((prop === 'background-image' || prop === 'content') && val.includes('url(') && !val.includes('data:')) {
+        val = 'none'
+      }
+      out[prop] = val
+    }
+  } else {
+    for (let i = 0; i < style.length; i++) {
+      const prop = style[i]
+      if (shouldIgnoreProp(prop)) continue
+      if (excludePred && excludePred(prop)) continue
+      let val = style.getPropertyValue(prop)
+      if ((prop === 'background-image' || prop === 'content') && val.includes('url(') && !val.includes('data:')) {
+        val = 'none'
+      }
+      out[prop] = val
+    }
+  }
+    // C8: Extra decoration/stroke/font loops are already covered by the allow-set
+  // (all those props are in MODULE_REQUIRED_PROPS). On the allow path they are
+  // guaranteed present, so skip the 17 extra getPropertyValue calls per node.
+  if (!allow) {
     // Asegurar props de decoración de texto (algunos motores no las listan en la iteración)
-  const EXTRA_TEXT_DECORATION_PROPS = [
-    'text-decoration-line',
-    'text-decoration-color',
-    'text-decoration-style',
-    'text-decoration-thickness',
-    'text-underline-offset',
-    'text-decoration-skip-ink'
-  ]
-  for (const prop of EXTRA_TEXT_DECORATION_PROPS) {
-    if (out[prop]) continue
-    try {
-      const v = style.getPropertyValue(prop)
-      if (v) out[prop] = v
-    } catch {}
-  }
-  // #340: -webkit-text-stroke en Safari – asegurar que se capture aunque no esté en la iteración
-  const TEXT_STROKE_PROPS = [
-    '-webkit-text-stroke',
-    '-webkit-text-stroke-width',
-    '-webkit-text-stroke-color',
-    'paint-order'
-  ]
-  for (const prop of TEXT_STROKE_PROPS) {
-    if (out[prop]) continue
-    try {
-      const v = style.getPropertyValue(prop)
-      if (v) out[prop] = v
-    } catch {}
-  }
-  if (options.embedFonts) {
-    const EXTRA_FONT_PROPS = [
-      'font-feature-settings',
-      'font-variation-settings',
-      'font-kerning',
-      'font-variant',
-      'font-variant-ligatures',
-      'font-optical-sizing',
+    const EXTRA_TEXT_DECORATION_PROPS = [
+      'text-decoration-line',
+      'text-decoration-color',
+      'text-decoration-style',
+      'text-decoration-thickness',
+      'text-underline-offset',
+      'text-decoration-skip-ink'
     ]
-    for (const prop of EXTRA_FONT_PROPS) {
+    for (const prop of EXTRA_TEXT_DECORATION_PROPS) {
       if (out[prop]) continue
       try {
         const v = style.getPropertyValue(prop)
         if (v) out[prop] = v
-      } catch { }
+      } catch {}
     }
+    // #340: -webkit-text-stroke en Safari – asegurar que se capture aunque no esté en la iteración
+    const TEXT_STROKE_PROPS = [
+      '-webkit-text-stroke',
+      '-webkit-text-stroke-width',
+      '-webkit-text-stroke-color',
+      'paint-order'
+    ]
+    for (const prop of TEXT_STROKE_PROPS) {
+      if (out[prop]) continue
+      try {
+        const v = style.getPropertyValue(prop)
+        if (v) out[prop] = v
+      } catch {}
+    }
+    if (options.embedFonts) {
+      const EXTRA_FONT_PROPS = [
+        'font-feature-settings',
+        'font-variation-settings',
+        'font-kerning',
+        'font-variant',
+        'font-variant-ligatures',
+        'font-optical-sizing',
+      ]
+      for (const prop of EXTRA_FONT_PROPS) {
+        if (out[prop]) continue
+        try {
+          const v = style.getPropertyValue(prop)
+          if (v) out[prop] = v
+        } catch { }
+      }
+    }
+    // content-visibility hidden — already in allow, but handle full-read fallback
+    try {
+      const cv = out['content-visibility'] || style.getPropertyValue('content-visibility')
+      if (cv === 'hidden') out['content-visibility'] = 'hidden'
+    } catch { /* ignore */ }
+  } else if (out['content-visibility'] === 'hidden') {
+    // On allow path, content-visibility is already captured if non-empty; nothing to do
   }
-  // Keep visibility as visibility. Unlike opacity, it is inherited but a child
-  // may explicitly restore `visibility: visible`; flattening a hidden ancestor to
-  // opacity:0 makes that legal, painted descendant impossible to recover.
-  // content-visibility:hidden skips the element's CONTENTS while still painting the
-  // element's own box (background, border, padding) — verified against real Chromium.
-  // Carry the declaration itself so the rasterizer applies those exact semantics: mapping
-  // it to visibility:hidden would erase the box too, and a descendant could override it
-  // back, which the real property does not allow. Read explicitly because
-  // content-visibility is not always enumerated in the style.length iteration.
-  try {
-    const cv = out['content-visibility'] || style.getPropertyValue('content-visibility')
-    if (cv === 'hidden') out['content-visibility'] = 'hidden'
-  } catch { /* ignore */ }
 
   // Flag whether inlineBackgroundImages has any work on this node (bg/mask/border-image or a
   // background-color that needs its layout longhands for background-clip:text). Read from the
@@ -167,15 +378,27 @@ function snapshotComputedStyleFull(style, options = {}) {
   // Stored non-enumerable so key generation/signature iteration never sees it.
   let needsBg = false
   {
-    const bgi = style.getPropertyValue('background-image')
+    // background-image is read from the live declaration, NOT `out`: the main loop rewrites
+    // url(non-data) → 'none' (lines 98-100), which would hide real bg work. Fast-path: a
+    // non-'none' value already in `out` is genuine bg work (gradients / data: urls are never
+    // rewritten), so we skip the live read in that case.
+    const outBgi = out['background-image']
+    const bgi = (outBgi && outBgi !== 'none') ? outBgi : style.getPropertyValue('background-image')
     if (bgi && bgi !== 'none') needsBg = true
     if (!needsBg) {
-      const bgc = style.getPropertyValue('background-color')
+      // background-color is never rewritten, so prefer the value already captured in `out`
+      // (falls back to the live declaration only when excludeStyleProps dropped it).
+      const bgc = (out['background-color'] !== undefined)
+        ? out['background-color']
+        : style.getPropertyValue('background-color')
       if (bgc && bgc !== 'rgba(0, 0, 0, 0)' && bgc !== 'transparent') needsBg = true
     }
     if (!needsBg) {
+      // These longhands are captured in the main loop, so read them from `out` and only fall
+      // back to the live declaration when excludeStyleProps excluded them or the engine did not
+      // enumerate them. Skips up to 9 getPropertyValue calls for the common no-mask/no-border-image node.
       for (const p of BG_INLINE_FLAG_PROPS) {
-        const v = style.getPropertyValue(p)
+        const v = (out[p] !== undefined) ? out[p] : style.getPropertyValue(p)
         if (v && v !== 'none') { needsBg = true; break }
       }
     }
@@ -189,26 +412,21 @@ function snapshotComputedStyleFull(style, options = {}) {
 
   // #362: Tailwind's * { border: 0 solid } renders incorrectly in capture.
   // When all border widths are 0, normalize to border: none for unambiguous output.
-  const bt = parseFloat(style.getPropertyValue('border-top-width') || 0) || 0
-  const br = parseFloat(style.getPropertyValue('border-right-width') || 0) || 0
-  const bb = parseFloat(style.getPropertyValue('border-bottom-width') || 0) || 0
-  const bl = parseFloat(style.getPropertyValue('border-left-width') || 0) || 0
+  // Prefer the values already captured in `out` (the main loop read them), falling back to
+  // the live declaration only when excludeStyleProps dropped them. Avoids 4-5
+  // getPropertyValue() calls per node - the same technique used for the BG-flag block above.
+  const bt = parseFloat(out['border-top-width'] ?? style.getPropertyValue('border-top-width')) || 0
+  const br = parseFloat(out['border-right-width'] ?? style.getPropertyValue('border-right-width')) || 0
+  const bb = parseFloat(out['border-bottom-width'] ?? style.getPropertyValue('border-bottom-width')) || 0
+  const bl = parseFloat(out['border-left-width'] ?? style.getPropertyValue('border-left-width')) || 0
   if (bt === 0 && br === 0 && bb === 0 && bl === 0) {
     // If border-image is being used (even with zero border widths), do NOT force
     // the shorthand `border: none` because it can override the intended rendering.
     // (Decorative border-image + 0 widths is valid CSS in some setups.)
-    const bis = (style.getPropertyValue('border-image-source') || '').trim()
+    const bis = ((out['border-image-source'] !== undefined
+      ? out['border-image-source']
+      : style.getPropertyValue('border-image-source')) || '').trim()
     const hasBorderImage = bis && bis !== 'none'
-    const BORDER_PROPS = [
-      'border', 'border-top', 'border-right', 'border-bottom', 'border-left',
-      'border-width', 'border-style', 'border-color',
-      'border-top-width', 'border-top-style', 'border-top-color',
-      'border-right-width', 'border-right-style', 'border-right-color',
-      'border-bottom-width', 'border-bottom-style', 'border-bottom-color',
-      'border-left-width', 'border-left-style', 'border-left-color',
-      'border-block', 'border-block-width', 'border-block-style', 'border-block-color',
-      'border-inline', 'border-inline-width', 'border-inline-style', 'border-inline-color',
-    ]
     for (const p of BORDER_PROPS) delete out[p]
     if (!hasBorderImage) out['border'] = 'none'
   }
@@ -323,6 +541,21 @@ function usedWidthDiffersFromAvailable(el, cs) {
 }
 
 const __snapshotSig = new WeakMap()
+
+// Hoisted: was an 8-element array allocated per node in stripHeightForWrappers.
+const STRIP_HEIGHT_TAGS = new Set(['div', 'section', 'article', 'main', 'aside', 'header', 'footer', 'nav'])
+
+// Hoisted: was allocated inside the zero-border-width block, which fires for most nodes.
+const BORDER_PROPS = [
+  'border', 'border-top', 'border-right', 'border-bottom', 'border-left',
+  'border-width', 'border-style', 'border-color',
+  'border-top-width', 'border-top-style', 'border-top-color',
+  'border-right-width', 'border-right-style', 'border-right-color',
+  'border-bottom-width', 'border-bottom-style', 'border-bottom-color',
+  'border-left-width', 'border-left-style', 'border-left-color',
+  'border-block', 'border-block-width', 'border-block-style', 'border-block-color',
+  'border-inline', 'border-inline-width', 'border-inline-style', 'border-inline-color',
+]
 function styleSignature(snap) {
   let sig = __snapshotSig.get(snap)
   if (sig) return sig
@@ -331,7 +564,36 @@ function styleSignature(snap) {
   __snapshotSig.set(snap, sig)
   return sig
 }
+// Structural snapshot cache: elements that are structurally identical (same tag, class,
+// inline style, and ancestor chain) are guaranteed to have identical computed styles, so
+// their ~350-property computed snapshot can be computed once and SHARED. In real DOMs the
+// vast majority of nodes are such siblings (e.g. table cells, list items, repeated rows),
+// so this collapses thousands of 350-getPropertyValue snapshots into a handful. The snapshot
+// object is immutable after creation, so sharing it across elements is safe. Keyed by a string
+// derived from the ancestor chain; parents are captured before children during a top-down walk.
+const __structKeyCache = new WeakMap()
+let __structSnapCache = null
+
+function structuralKey(el) {
+  let k = __structKeyCache.get(el)
+  if (k !== undefined) return k
+  const parent = el.parentNode
+  const parentKey = parent && parent.nodeType === 1 ? structuralKey(parent) : ''
+  k = `${parentKey}|${el.tagName}|${el.className}|${el.style ? el.style.cssText : ''}`
+  __structKeyCache.set(el, k)
+  return k
+}
+
 function getSnapshot(el, preStyle = null, options = {}) {
+  // PERF-5: piggyback inline-style collection on the snapshot walk itself (no extra
+  // tree walk). Each node's own inline props are added to the global allow-set
+  // before its snapshot is taken, so parents' inline props are already present
+  // for children (top-down walk). This keeps the set minimal and pixel-perfect
+  // without an extra O(n) pass.
+  const usedSet = getUsedPropSet(__epoch)
+  if (usedSet && el.style) {
+    for (let i = 0; i < el.style.length; i++) addWithExpansion(el.style[i], usedSet)
+  }
   const rec = snapshotCache.get(el)
   // The snapshot content depends on embedFonts (extra font props) and excludeStyleProps
   // (skipped props), but __epoch only bumps on DOM/font mutation — not option changes.
@@ -340,6 +602,23 @@ function getSnapshot(el, preStyle = null, options = {}) {
   const ef = !!(options && options.embedFonts)
   const ex = (options && options.excludeStyleProps) || null
   if (rec && rec.epoch === __epoch && rec.embedFonts === ef && rec.excludeStyleProps === ex) return rec.snapshot
+  // Structural sharing only applies to the common default-options path: embedFonts/exclude
+  // change the snapshot shape, so fall back to the per-element cache for those.
+  if (!ef && !ex) {
+    if (!__structSnapCache || __structSnapEpoch !== __epoch) {
+      __structSnapCache = new Map()
+      __structSnapEpoch = __epoch
+    }
+    const skey = structuralKey(el)
+    const shared = __structSnapCache.get(skey)
+    if (shared) return shared
+    const style = preStyle || getComputedStyle(el)
+    const snap = snapshotComputedStyleFull(style, options)
+    stripHeightForWrappers(el, style, snap)
+    __structSnapCache.set(skey, snap)
+    snapshotCache.set(el, { epoch: __epoch, snapshot: snap, embedFonts: ef, excludeStyleProps: ex })
+    return snap
+  }
   const style = preStyle || getComputedStyle(el)
   const snap = snapshotComputedStyleFull(style, options)
   stripHeightForWrappers(el, style, snap)
@@ -347,35 +626,32 @@ function getSnapshot(el, preStyle = null, options = {}) {
   return snap
 }
 
+const _persistSingleton = {
+  snapshotKeyCache,
+  defaultStyle: cache.defaultStyle,
+  baseStyle: cache.baseStyle,
+  image: cache.image,
+  resource: cache.resource,
+  background: cache.background,
+  font: cache.font,
+}
 function _resolveCtx(sessionOrCtx, opts) {
   if (sessionOrCtx && sessionOrCtx.session && sessionOrCtx.persist) return sessionOrCtx
   if (sessionOrCtx && (sessionOrCtx.styleMap || sessionOrCtx.styleCache || sessionOrCtx.nodeMap)) {
-    return {
+    // C3: memoize on session object to avoid 2 allocs per node
+    if (sessionOrCtx.__ctx && sessionOrCtx.__ctx.options === (opts || {})) return sessionOrCtx.__ctx
+    const ctx = {
       session: sessionOrCtx,
-      persist: {
-        snapshotKeyCache,
-        defaultStyle: cache.defaultStyle,
-        baseStyle: cache.baseStyle,
-        image: cache.image,
-        resource: cache.resource,
-        background: cache.background,
-        font: cache.font,
-      },
+      persist: _persistSingleton,
       options: opts || {},
     }
+    try { sessionOrCtx.__ctx = ctx } catch {}
+    return ctx
   }
 
   return {
     session: cache.session,
-    persist: {
-      snapshotKeyCache,
-      defaultStyle: cache.defaultStyle,
-      baseStyle: cache.baseStyle,
-      image: cache.image,
-      resource: cache.resource,
-      background: cache.background,
-      font: cache.font,
-    },
+    persist: _persistSingleton,
     options: (sessionOrCtx || opts || {}),
   }
 }
@@ -399,6 +675,20 @@ function normalizeInlineStyleToComputed(source, clone, computed) {
 
 export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
   if (source.tagName === 'STYLE') return
+  // B2: Skip snapshot entirely for NO_DEFAULTS_TAGS (SVG). These tags never produce a class
+  // (getStyleKey returns ''), but currently pay for a full 137-prop snapshot + signature + key.
+  // On icon sets/charts with thousands of <path> elements this is hundreds of thousands of
+  // wasted getPropertyValue calls. Hoist the check here.
+  const tagLower = source.tagName ? source.tagName.toLowerCase() : ''
+  if (NO_DEFAULTS_TAGS.has(tagLower)) {
+    const ctx2 = _resolveCtx(sessionOrCtx, opts)
+    ctx2.session.styleMap.set(clone, '')
+    // Provide minimal snapshot for needsBackgroundInline (these tags never have CSS bg)
+    const mSnap = {}
+    Object.defineProperty(mSnap, '__needsBgInline', { value: false, enumerable: false })
+    snapshotCache.set(source, { epoch: __epoch, snapshot: mSnap, embedFonts: false, excludeStyleProps: null })
+    return
+  }
 
   const ctx = _resolveCtx(sessionOrCtx, opts)
   const resetMode = (ctx.options && ctx.options.cache) || 'auto'
@@ -419,7 +709,14 @@ export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
     // element never throws and callers always receive a usable style object.
     let computed = null
     try { computed = getComputedStyle(source) } catch { /* detached / cross-origin */ }
-    session.styleCache.set(source, computed || getComputedStyle(document.documentElement))
+    const final = computed || getComputedStyle(document.documentElement)
+    session.styleCache.set(source, final)
+    // Populate the global cache as well so getStyle(parent) hits without a second gcs
+    try {
+      let m = cache.computedStyle.get(source)
+      if (!m) { m = new Map(); cache.computedStyle.set(source, m) }
+      if (!m.has(null)) m.set(null, final)
+    } catch {}
   }
   const pre = session.styleCache.get(source)
 
@@ -446,49 +743,37 @@ export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
   const snap = getSnapshot(source, pre, ctx.options)
 
   const flexItem = isFlexOrGridItem(source)
-
-  // #406: foreignObject may resolve min-width:auto differently than normal DOM
-  // for flex/grid items. Explicitly set min-width:0 on flex/grid items that have
-  // the default auto value, so the generated CSS class includes it and we don't
-  // need a blanket foreignObject *{min-width:0} rule (which breaks inline-flex+gap).
-  if (flexItem) {
-    const mw = pre.getPropertyValue('min-width')
-    if (!mw || mw === 'auto' || mw === '0px') {
-      snap['min-width'] = '0px'
+  let snapForKey = snap
+  if (flexItem && (!snap['min-width'] || snap['min-width'] === 'auto' || snap['min-width'] === '0px')) {
+    snapForKey = { ...snap, 'min-width': '0px' }
+    if (snap.__needsBgInline !== undefined) {
+      Object.defineProperty(snapForKey, '__needsBgInline', { value: snap.__needsBgInline, enumerable: false })
     }
   }
 
   const tag = source.tagName?.toLowerCase() || 'div'
-  // getStyleKey only softens width for inline-sized / table / inline boxes, and only there does
-  // its output depend on content/flex-item-ness. For every other node (the vast majority — divs,
-  // headings, paragraphs…) skip that bookkeeping entirely so the hot path stays untouched.
-  let sig = styleSignature(snap)
+  let sig = styleSignature(snapForKey)
   let sizedByContent = true
-  if (softensWidth(tag, (snap.display || '').toLowerCase())) {
+  if (softensWidth(tag, (snapForKey.display || '').toLowerCase())) {
     sizedByContent = hasRenderedContent(source)
-    // #484: softening only reproduces the box when its `width` is auto. On a blockified box in
-    // normal flow (`span{display:block;width:16px}`) the min-width floor cannot cap the stretch,
-    // and a flex/grid item gets no floor at all (#406) — both lost the authored width. Treat an
-    // author-specified width as "not sized by content" so it is kept verbatim.
-    if (sizedByContent && softenNeedsAutoWidth(tag, snap, flexItem) &&
+    if (sizedByContent && softenNeedsAutoWidth(tag, snapForKey, flexItem) &&
         hasSpecifiedWidth(source, pre, flexItem)) {
       sizedByContent = false
     }
     // Fold tag/content/flex into the cache key so soften-eligible elements with identical styles
     // but different shape don't collide on the shared snapshotKeyCache.
     sig = `${sig}|${tag}${sizedByContent ? '|c' : ''}${flexItem ? '|f' : ''}`
-    // This is the exact condition getStyleKey uses to actually drop the width (the #429/#433/
-    // #434 family): tally it so capture.js can suggest `reconcile: true` when it's never used —
-    // cheap, since softensWidth/sizedByContent are already computed for this node regardless.
-    // Nowrap/pre boxes stay frozen (#474), so they carry no re-wrap risk.
-    const wsMode = snap['text-wrap-mode'] || snap['white-space'] || ''
+    const wsMode = snapForKey['text-wrap-mode'] || snapForKey['white-space'] || ''
     if (sizedByContent && wsMode !== 'nowrap' && wsMode !== 'pre') {
       session.reconcileRisk = (session.reconcileRisk || 0) + 1
     }
   }
+  // Memoize the style key by signature. Most nodes share a signature with their siblings, so this
+  // turns a full getStyleKey() computation into an O(1) hit. Measured: bypassing this cache makes
+  // large captures ~2x SLOWER, so it must not be removed.
   let key = persist.snapshotKeyCache.get(sig)
   if (key === undefined) {
-    key = getStyleKey(snap, tag, sizedByContent, flexItem)
+    key = getStyleKey(snapForKey, tag, sizedByContent, flexItem)
     persist.snapshotKeyCache.set(sig, key)
   }
   session.styleMap.set(clone, key)
@@ -609,8 +894,7 @@ function stripHeightForWrappers(el, cs, snap) {
 
   // 2) Solo div/section/article/main/aside/header/footer/nav (no ol/ul/li: layout de listas)
   const tag = el.tagName && el.tagName.toLowerCase()
-  const ALLOWED_TAGS = ['div', 'section', 'article', 'main', 'aside', 'header', 'footer', 'nav']
-  if (!tag || !ALLOWED_TAGS.includes(tag)) return
+  if (!tag || !STRIP_HEIGHT_TAGS.has(tag)) return
 
   // 2c) aspect-ratio define dimensiones derivadas; respetar
   if (cs.aspectRatio && cs.aspectRatio !== 'none' && cs.aspectRatio !== 'auto') return

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -1,4 +1,4 @@
-import { getStyleKey, softensWidth, softenNeedsAutoWidth, shouldIgnoreProp, getStyle, NO_DEFAULTS_TAGS, _invalidateSplitCaches } from '../utils/index.js'
+import { getDefaultStyleForTag, getStyleKey, softensWidth, softenNeedsAutoWidth, shouldIgnoreProp, getStyle, NO_DEFAULTS_TAGS, _invalidateSplitCaches } from '../utils/index.js'
 import { cache } from '../core/cache.js'
 
 const snapshotCache = new WeakMap()
@@ -8,11 +8,10 @@ const snapshotKeyCache = new Map()
  *  unique element styles, this Map can grow without bound and leak memory. */
 const MAX_SNAPSHOT_KEY_CACHE = 2000
 let __epoch = 0
-let __structSnapEpoch = -1
+// Per-document allow-list state: Document -> {epoch, set:Set|null, fingerprint:string|null}
+const __docState = new WeakMap()
 function bumpEpoch() {
   __epoch++
-  __structSnapEpoch = -1
-  __structSnapCache = null
   try { _invalidateSplitCaches?.() } catch {}
   // Evict when oversized — entries are cheap to rebuild on the next capture.
   if (snapshotKeyCache.size > MAX_SNAPSHOT_KEY_CACHE) snapshotKeyCache.clear()
@@ -43,21 +42,26 @@ export function hasExternalMutation(records) {
   return false
 }
 
-let __wired = false
+const __wiredDocs = new WeakMap()
 function setupInvalidationOnce(root = document.documentElement) {
-  if (__wired) return
-  __wired = true
+  const doc = (root && root.ownerDocument) || document
+  if (__wiredDocs.has(doc)) return
+  __wiredDocs.set(doc, true)
   const onRecords = (records) => { if (hasExternalMutation(records)) bumpEpoch() }
   try {
+    const target = doc.documentElement || root
     const domObs = new MutationObserver(onRecords)
-    domObs.observe(root, { subtree: true, childList: true, characterData: true, attributes: true })
+    domObs.observe(target, { subtree: true, childList: true, characterData: true, attributes: true })
   } catch { }
   try {
-    const headObs = new MutationObserver(onRecords)
-    headObs.observe(document.head, { subtree: true, childList: true, characterData: true, attributes: true })
+    const head = doc.head
+    if (head) {
+      const headObs = new MutationObserver(onRecords)
+      headObs.observe(head, { subtree: true, childList: true, characterData: true, attributes: true })
+    }
   } catch { }
   try {
-    const f = document.fonts
+    const f = doc.fonts || document.fonts
     if (f) {
       f.addEventListener?.('loadingdone', bumpEpoch)
       f.ready?.then(() => bumpEpoch()).catch(() => { })
@@ -116,11 +120,18 @@ const SHORTHAND_EXPANSIONS = new Map([
 ])
 function addWithExpansion(prop, set) {
   if (shouldIgnoreProp(prop)) return
-  set.add(prop)
   const ex = SHORTHAND_EXPANSIONS.get(prop)
-  if (ex) for (const p of ex) {
-    if (!shouldIgnoreProp(p)) set.add(p)
+  // A shorthand carries exactly its longhands' information, so only the longhands enter
+  // the set: snapshots stay shorthand-free (smaller signatures/keys, fewer
+  // getPropertyValue calls per node) while getStyleKey emits identical CSS from longhands.
+  // Shorthands without an expansion (grid, mask, border-image, …) are kept as-is.
+  if (ex) {
+    for (const p of ex) {
+      if (!shouldIgnoreProp(p)) set.add(p)
+    }
+    return
   }
+  set.add(prop)
 }
 const MODULE_REQUIRED_PROPS = [
   'background-image', 'background-color', 'content-visibility',
@@ -149,134 +160,264 @@ const MODULE_REQUIRED_PROPS = [
   'background-position','background-position-x','background-position-y','background-size','background-repeat','background-origin','background-clip','background-attachment','background-blend-mode',
   'border-image-slice','border-image-width','border-image-outset','border-image-repeat'
 ]
-let __usedPropSet = null
-let __usedPropEpoch = -1
-function getUsedPropSet(epoch) {
-  // Debug escape hatch: window.__SNAPDOM_FULL_PROPS forces the legacy full read
-  // (used by the PERF-5 pixel-equivalence verification test).
-  if (typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) return null
-  if (__usedPropSet && __usedPropEpoch === epoch) {
-    return __usedPropSet
-  }
+/** Collect every open ShadowRoot under a start element, recursing through nested hosts. */
+function collectShadowRootsFrom(startEl) {
+  const out = []
+  try {
+    if (!startEl) return out
+    const stack = [startEl]
+    const seen = new Set()
+    while (stack.length) {
+      const el = stack.pop()
+      if (!el || seen.has(el)) continue
+      seen.add(el)
+      let sr = null
+      try { sr = el.shadowRoot } catch {}
+      if (sr) {
+        out.push(sr)
+        for (let i = sr.children.length - 1; i >= 0; i--) stack.push(sr.children[i])
+      }
+      const kids = el.children
+      if (kids) for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i])
+    }
+  } catch {}
+  return out
+}
+
+/** Shadow scopes relevant to a capture root: descendants' scopes plus any scopes above the
+ *  root (capturing inside a shadow tree still inherits them). Document author styles are
+ *  global, but shadow styles only apply inside their tree, so small captures no longer pay
+ *  a whole-document walk. */
+function collectCaptureShadowRoots(root) {
+  const out = collectShadowRootsFrom(root)
+  try {
+    const seen = new Set(out)
+    let n = root
+    while (n) {
+      const r = n.getRootNode ? n.getRootNode() : null
+      if (r && r instanceof ShadowRoot) {
+        if (!seen.has(r)) { seen.add(r); out.push(r) }
+        n = r.host
+      } else break
+    }
+  } catch {}
+  return out
+}
+
+/**
+ * Build the allow-set and a fingerprint for a document in ONE scan.
+ * Fingerprint is a join of sheet identity + cssText; any CSSOM mutation that
+ * changes values or structure changes the fingerprint. Cross-origin denial
+ * yields {set:null, fingerprint:null} fallback.
+ */
+function buildAllowSetAndFingerprint(doc, root) {
   const set = new Set()
   for (const p of MODULE_REQUIRED_PROPS) addWithExpansion(p, set)
+  const hashParts = []
+  let readable = true
   const collectFromSheets = (sheets) => {
     for (const sheet of sheets) {
       let rules
-      try { rules = sheet.cssRules } catch { continue }
+      try { rules = sheet.cssRules } catch { return false }
       if (!rules) continue
-      collectSheetProps(rules, set)
+      try { hashParts.push(`sheet:${sheet.href||''}:${sheet.disabled}:${sheet.media?sheet.media.mediaText:''}:${rules.length}`) } catch {}
+      if (!collectSheetProps(rules, set, hashParts)) return false
     }
+    return true
   }
   try {
-    collectFromSheets(document.styleSheets)
-    // adoptedStyleSheets (Lit, Constructable Stylesheets)
-    const adopted = document.adoptedStyleSheets
-    if (Array.isArray(adopted) && adopted.length) collectFromSheets(adopted)
-    // Shadow roots in the document (best-effort: walk from capture root when available,
-    // but also scan all elements with shadowRoot)
-    try {
-      const walker = document.createTreeWalker(document.documentElement, NodeFilter.SHOW_ELEMENT)
-      let n
-      while ((n = walker.nextNode())) {
-        const sr = n.shadowRoot
-        if (sr) {
-          if (sr.adoptedStyleSheets && sr.adoptedStyleSheets.length) collectFromSheets(sr.adoptedStyleSheets)
-          // shadowRoot.styleSheets is not standard but some polyfills expose it
-          if (sr.styleSheets) {
-            try { collectFromSheets(sr.styleSheets) } catch {}
-          }
-          // Inline <style> inside shadow root
+    readable = collectFromSheets(doc.styleSheets)
+    if (readable) {
+      const adopted = doc.adoptedStyleSheets
+      if (adopted && adopted.length) readable = collectFromSheets(adopted)
+    }
+    if (readable) {
+      const shadowRoots = (root && root.nodeType === 1)
+        ? collectCaptureShadowRoots(root)
+        : collectShadowRootsFrom(doc.documentElement)
+      for (const sr of shadowRoots) {
+        if (!readable) break
+        if (sr.adoptedStyleSheets && sr.adoptedStyleSheets.length) {
+          readable = collectFromSheets(sr.adoptedStyleSheets)
+        }
+        if (readable && sr.styleSheets) {
+          try { readable = collectFromSheets(sr.styleSheets) } catch { readable = false }
+        }
+        if (readable) {
           for (const st of sr.querySelectorAll('style')) {
             const sheet = st.sheet
             if (sheet) {
-              try { collectSheetProps(sheet.cssRules || [], set) } catch {}
+              let rules
+              try { rules = sheet.cssRules } catch { readable = false; break }
+              if (rules && !collectSheetProps(rules, set, hashParts)) { readable = false; break }
+              try { hashParts.push(`style:${st.textContent?st.textContent.length:0}`) } catch {}
+            } else {
+              try { hashParts.push(`style:text:${st.textContent||''}`) } catch {}
+              const m = st.textContent ? st.textContent.match(/([a-z-]+)\s*:/gi) : null
+              if (m) for (const raw of m) addWithExpansion(raw.slice(0,-1).trim().toLowerCase(), set)
             }
           }
         }
       }
-    } catch {}
-  } catch { /* cross-origin / empty */ }
-  // A3: UA stylesheet diff — ensure properties where UA differs from initial are included
-  // (white-space:pre for <pre>, text-align:center for <th>, list-style-type, etc.)
-  // Cheap: ~30 tags × one style read, diff vs initial, union into allow-set.
-  try {
-    const uaTags = ['pre','th','td','ol','ul','li','sub','sup','select','input','button','table','caption','blockquote','h1','h2','h3','p','a']
-    for (const tag of uaTags) {
-      const defaults = getDefaultStyleForTag(tag)
-      // Probe without all:initial to get UA value
-      let probe
-      try {
-        const sandbox = document.getElementById('snapdom-sandbox')
-        // Reuse sandbox logic: create element without all:initial
-        const tmp = document.createElement(tag)
-        const parent = sandbox || document.body
-        parent.appendChild(tmp)
-        const cs = getComputedStyle(tmp)
-        for (let i = 0; i < cs.length; i++) {
-          const prop = cs[i]
-          if (set.has(prop) || shouldIgnoreProp(prop)) continue
-          const uaVal = cs.getPropertyValue(prop)
-          const initVal = defaults[prop]
-          if (uaVal && initVal !== undefined && uaVal !== initVal) {
-            // Only add if UA value is not initial — it can affect rendering in foreignObject
-            // where we reset to initial via baseCSS
-            addWithExpansion(prop, set)
-          }
-        }
-        parent.removeChild(tmp)
-      } catch {}
     }
-  } catch {}
-  __usedPropSet = set
-  __usedPropEpoch = epoch
+  } catch { readable = false }
+  if (!readable) return { set: null, sorted: null, fingerprint: null, usesVars: true }
+  const sorted = [...set].sort()
+  const fingerprint = hashParts.join('\n')
+  return { set, sorted, fingerprint, usesVars: VAR_RE.test(fingerprint) }
+}
+
+// Epoch-keyed flag: does any scanned author CSS use var()? Lets resolveCSSVars skip its
+// per-node baseline comparison (1 getComputedStyle + 5 getPropertyValue per node) on
+// var-free pages. Unknown epoch → true (today's thorough path). seedUsedProps rebuilds
+// every capture, so CSSOM-inserted var() rules are picked up on the next capture.
+const VAR_RE = /var\(/i
+let __authorVarsEpoch = -1
+let __authorVarsSeen = true
+function noteAuthorVars(epoch, usesVars, readable) {
+  if (__authorVarsEpoch !== epoch) { __authorVarsEpoch = epoch; __authorVarsSeen = false }
+  if (!readable || usesVars) __authorVarsSeen = true
+}
+export function authorUsesCssVars() {
+  return __authorVarsEpoch === __epoch ? __authorVarsSeen : true
+}
+
+function getUsedPropSetForDoc(doc, epoch) {
+  if (typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) return null
+  const state = __docState.get(doc)
+  if (state && state.epoch === epoch) return state.set
+  const { set, sorted, fingerprint, usesVars } = buildAllowSetAndFingerprint(doc, null)
+  noteAuthorVars(epoch, usesVars, fingerprint !== null)
+  __docState.set(doc, { epoch, set, sorted, fingerprint })
   return set
 }
 
-/** Build (once per epoch) the used-prop allow-set and seed it with the captured subtree's
- *  inline-style property names. Call from prepareClone before the snapshot walk. */
+/** Build (once per capture) the used-prop allow-set. Call from prepareClone before the
+ *  snapshot walk. Per-node inline props are piggybacked top-down inside getSnapshot, so no
+ *  whole-subtree pre-walk is needed here (it was a redundant O(n) pass that also desynced
+ *  `sorted` from `set`). */
 export function seedUsedProps(root) {
-  const set = getUsedPropSet(__epoch)
-  if (set) seedInlineProps(root, set)
+  const doc = (root && root.ownerDocument) || document
+  const before = __docState.get(doc)
+  const beforeFp = before ? before.fingerprint : undefined
+  const beforeEpoch = before ? before.epoch : -1
+  const { set, sorted, fingerprint, usesVars } = buildAllowSetAndFingerprint(doc, root)
+  // Any fingerprint change that is not already covered by a DOM-mutation epoch bump
+  // must invalidate snapshots: CSSOM APIs (insertRule/deleteRule/replaceSync,
+  // adoptedStyleSheets assignment, rule.style mutation) do not fire MutationObserver.
+  if (beforeFp !== undefined && fingerprint !== beforeFp && beforeEpoch === __epoch) {
+    if (!(beforeFp === null && fingerprint === null)) bumpEpoch()
+  }
+  noteAuthorVars(__epoch, usesVars, fingerprint !== null)
+  __docState.set(doc, { epoch: __epoch, set, sorted, fingerprint })
 }
-export function getUsedPropSetDebug() { return __usedPropSet }
+export function getUsedPropSetDebug(doc) {
+  const targetDoc = doc || document
+  const state = __docState.get(targetDoc)
+  return state ? state.set : null
+}
+// Back-compat: tests that call getUsedPropSetDebug without arg get top-doc
 export function getCachedSnapshot(el) {
   const rec = snapshotCache.get(el)
   return rec && rec.epoch === __epoch ? rec.snapshot : null
 }
 export { snapshotComputedStyleFull }
-function collectSheetProps(rules, set) {
+function collectSheetProps(rules, set, hashParts) {
   for (const rule of rules) {
-    // @import: CSSImportRule exposes sheet via rule.styleSheet
     if (rule.styleSheet) {
       try {
         const importedRules = rule.styleSheet.cssRules
-        if (importedRules) collectSheetProps(importedRules, set)
-      } catch { /* cross-origin import */ }
+        if (importedRules) {
+          try { hashParts && hashParts.push(`import:${rule.styleSheet.href||''}`) } catch {}
+          if (!collectSheetProps(importedRules, set, hashParts)) return false
+        }
+      } catch { return false }
     }
-    if (rule.style) for (let i = 0; i < rule.style.length; i++) addWithExpansion(rule.style[i], set)
-    if (rule.cssRules) collectSheetProps(rule.cssRules, set)
+    let nestedRules = null
+    try { nestedRules = rule.cssRules } catch { return false }
+    if (nestedRules && nestedRules.length) {
+      // Container rule (@media/@supports/@keyframes/…): its cssText duplicates every nested
+      // rule below, so fingerprint the header only and recurse for contents. Any value,
+      // selector, or condition change still flips the fingerprint via the header or a leaf.
+      try { hashParts && hashParts.push(`@${rule.constructor?.name || rule.type}:${rule.conditionText || rule.name || ''}:${nestedRules.length}`) } catch {}
+      if (!collectSheetProps(nestedRules, set, hashParts)) return false
+      continue
+    }
+    if (rule.style) {
+      for (let i = 0; i < rule.style.length; i++) addWithExpansion(rule.style[i], set)
+    }
+    // rule.cssText already contains the declarations — no separate style.cssText push.
+    try { hashParts && hashParts.push(rule.cssText) } catch {}
   }
+  return true
 }
 
-// Seed the allow-set with the inline-style property names of every node in the captured
-// subtree. O(n) with NO getComputedStyle calls (we read element.style names directly), so
-// it is cheap. Authoring via inline style is extremely common (snapdom itself, component
-// frameworks), and without this the allow-set would wrongly drop such props.
-function seedInlineProps(root, set) {
-  const stack = [root]
-  while (stack.length) {
-    const n = stack.pop()
-    if (n.style) for (let i = 0; i < n.style.length; i++) addWithExpansion(n.style[i], set)
-    const kids = n.children
-    for (let i = 0; i < kids.length; i++) stack.push(kids[i])
+let __uaProbeEpoch = -1
+let __uaProbeKeys = new Set()
+
+function uaProbeKey(el) {
+  let key = el.tagName || ''
+  const attrs = []
+  for (let i = 0; i < el.attributes.length; i++) {
+    const attr = el.attributes[i]
+    const name = attr.name.toLowerCase()
+    // Author selectors for these are already represented by the stylesheet allow-list.
+    // Keep native/presentational attributes, which can change UA styles for form controls,
+    // tables, lists, hidden/details state, writing direction, and legacy HTML markup.
+    if (name === 'class' || name === 'id' || name === 'style' ||
+        name.startsWith('data-') || name.startsWith('aria-')) continue
+    attrs.push(`${name}=${attr.value}`)
+  }
+  if (attrs.length) key += `|${attrs.sort().join('|')}`
+  // Some live form states do not reflect back to attributes.
+  if ('checked' in el) key += `|checked=${!!el.checked}|indeterminate=${!!el.indeterminate}`
+  if ('selected' in el) key += `|selected=${!!el.selected}`
+  return key
+}
+
+/** Add properties whose live UA/presentational value differs from CSS `initial`.
+ *  The caller already owns the computed declaration, so this costs one property-name walk per
+ *  tag/native-attribute variant and no extra getComputedStyle or temporary DOM nodes. */
+function collectElementUAProps(el, style, set, epoch) {
+  if (__uaProbeEpoch !== epoch) {
+    __uaProbeEpoch = epoch
+    __uaProbeKeys = new Set()
+  }
+  const key = uaProbeKey(el)
+  if (__uaProbeKeys.has(key)) return true
+  try {
+    const defaults = getDefaultStyleForTag(el.tagName)
+    for (let i = 0; i < style.length; i++) {
+      const prop = style[i]
+      if (set.has(prop) || shouldIgnoreProp(prop)) continue
+      const value = style.getPropertyValue(prop)
+      if (value && value !== defaults[prop]) addWithExpansion(prop, set)
+    }
+    __uaProbeKeys.add(key)
+    return true
+  } catch {
+    return false
   }
 }
 
 function snapshotComputedStyleFull(style, options = {}) {
   const out = {}
   const excludeStyleProps = options.excludeStyleProps
-  const allow = options.__usedProps || ((typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) ? null : (__usedPropSet && __usedPropEpoch === __epoch ? __usedPropSet : null))
+  let allow = options.__usedProps
+  let allowSorted = options.__usedPropsSorted || null
+  if (allow === undefined) {
+    if (typeof window !== 'undefined' && window.__SNAPDOM_FULL_PROPS) allow = null
+    else {
+      const st = __docState.get(document)
+      allow = st && st.epoch === __epoch ? st.set : null
+      allowSorted = st && st.epoch === __epoch ? st.sorted : null
+      // getSnapshot already passes the per-document set via __usedProps, so this
+      // fallback is only for legacy direct calls without a capture context.
+    }
+  }
+  // Use pre-sorted array when available to build `out` in sorted insertion order
+  // so styleSignature can avoid per-node sort.
+  const allowIter = allowSorted || (allow ? [...allow].sort() : null)
   // C3 micro: normalize exclude predicate once per snapshot, not per prop
   let excludePred = null
   if (excludeStyleProps) {
@@ -287,8 +428,12 @@ function snapshotComputedStyleFull(style, options = {}) {
       excludePred = excludeStyleProps
     }
   }
-  if (allow) {
-    for (const prop of allow) {
+  // Same-declaration re-reads: `out` was just built from `style`, so on the allow path
+  // without exclusions a value missing from `out` is already known-empty — re-reading it
+  // live repeats the C++ call for the identical answer.
+  const needLive = !allowIter || !!excludePred
+  if (allowIter) {
+    for (const prop of allowIter) {
       // A5: custom properties already filtered at insertion, but keep guard for safety
       if (prop[0] === '-' && prop[1] === '-') continue
       if (excludePred && excludePred(prop)) continue
@@ -315,7 +460,7 @@ function snapshotComputedStyleFull(style, options = {}) {
     // C8: Extra decoration/stroke/font loops are already covered by the allow-set
   // (all those props are in MODULE_REQUIRED_PROPS). On the allow path they are
   // guaranteed present, so skip the 17 extra getPropertyValue calls per node.
-  if (!allow) {
+  if (!allowIter) {
     // Asegurar props de decoración de texto (algunos motores no las listan en la iteración)
     const EXTRA_TEXT_DECORATION_PROPS = [
       'text-decoration-line',
@@ -383,14 +528,14 @@ function snapshotComputedStyleFull(style, options = {}) {
     // non-'none' value already in `out` is genuine bg work (gradients / data: urls are never
     // rewritten), so we skip the live read in that case.
     const outBgi = out['background-image']
-    const bgi = (outBgi && outBgi !== 'none') ? outBgi : style.getPropertyValue('background-image')
+    const bgi = (outBgi && outBgi !== 'none') ? outBgi : (needLive ? style.getPropertyValue('background-image') : '')
     if (bgi && bgi !== 'none') needsBg = true
     if (!needsBg) {
       // background-color is never rewritten, so prefer the value already captured in `out`
       // (falls back to the live declaration only when excludeStyleProps dropped it).
       const bgc = (out['background-color'] !== undefined)
         ? out['background-color']
-        : style.getPropertyValue('background-color')
+        : (needLive ? style.getPropertyValue('background-color') : '')
       if (bgc && bgc !== 'rgba(0, 0, 0, 0)' && bgc !== 'transparent') needsBg = true
     }
     if (!needsBg) {
@@ -398,7 +543,7 @@ function snapshotComputedStyleFull(style, options = {}) {
       // back to the live declaration when excludeStyleProps excluded them or the engine did not
       // enumerate them. Skips up to 9 getPropertyValue calls for the common no-mask/no-border-image node.
       for (const p of BG_INLINE_FLAG_PROPS) {
-        const v = (out[p] !== undefined) ? out[p] : style.getPropertyValue(p)
+        const v = (out[p] !== undefined) ? out[p] : (needLive ? style.getPropertyValue(p) : '')
         if (v && v !== 'none') { needsBg = true; break }
       }
     }
@@ -559,40 +704,52 @@ const BORDER_PROPS = [
 function styleSignature(snap) {
   let sig = __snapshotSig.get(snap)
   if (sig) return sig
-  const entries = Object.entries(snap).sort((a, b) => a[0] < b[0] ? -1 : (a[0] > b[0] ? 1 : 0))
-  sig = entries.map(([k, v]) => `${k}:${v}`).join(';')
+  // Snap is built in sorted key order (see snapshotComputedStyleFull with sorted allow),
+  // so Object.keys is already sorted; joining without sort is both faster and canonical.
+  // Fallback to sort only for legacy snaps not built sorted.
+  const keys = Object.keys(snap)
+  let isSorted = true
+  for (let i = 1; i < keys.length; i++) if (keys[i] < keys[i-1]) { isSorted = false; break }
+  if (isSorted) sig = keys.map(k => `${k}:${snap[k]}`).join(';')
+  else {
+    const entries = Object.entries(snap).sort((a, b) => a[0] < b[0] ? -1 : (a[0] > b[0] ? 1 : 0))
+    sig = entries.map(([k, v]) => `${k}:${v}`).join(';')
+  }
   __snapshotSig.set(snap, sig)
   return sig
 }
-// Structural snapshot cache: elements that are structurally identical (same tag, class,
-// inline style, and ancestor chain) are guaranteed to have identical computed styles, so
-// their ~350-property computed snapshot can be computed once and SHARED. In real DOMs the
-// vast majority of nodes are such siblings (e.g. table cells, list items, repeated rows),
-// so this collapses thousands of 350-getPropertyValue snapshots into a handful. The snapshot
-// object is immutable after creation, so sharing it across elements is safe. Keyed by a string
-// derived from the ancestor chain; parents are captured before children during a top-down walk.
-const __structKeyCache = new WeakMap()
-let __structSnapCache = null
-
-function structuralKey(el) {
-  let k = __structKeyCache.get(el)
-  if (k !== undefined) return k
-  const parent = el.parentNode
-  const parentKey = parent && parent.nodeType === 1 ? structuralKey(parent) : ''
-  k = `${parentKey}|${el.tagName}|${el.className}|${el.style ? el.style.cssText : ''}`
-  __structKeyCache.set(el, k)
-  return k
-}
-
 function getSnapshot(el, preStyle = null, options = {}) {
+  const doc = (el && el.ownerDocument) || document
+  const style = preStyle || getStyle(el)
   // PERF-5: piggyback inline-style collection on the snapshot walk itself (no extra
-  // tree walk). Each node's own inline props are added to the global allow-set
+  // tree walk). Each node's own inline props are added to the per-document allow-set
   // before its snapshot is taken, so parents' inline props are already present
   // for children (top-down walk). This keeps the set minimal and pixel-perfect
   // without an extra O(n) pass.
-  const usedSet = getUsedPropSet(__epoch)
+  let usedSet = getUsedPropSetForDoc(doc, __epoch)
+  let usedSorted = null
+  const state = __docState.get(doc)
+  if (state && state.epoch === __epoch) usedSorted = state.sorted || null
   if (usedSet && el.style) {
+    const beforeSize = usedSet.size
     for (let i = 0; i < el.style.length; i++) addWithExpansion(el.style[i], usedSet)
+    if (usedSet.size !== beforeSize && state) {
+      // Keep sorted array in sync without full resort per node when only few props added
+      // Resort is cheap for 137 entries and happens only when a new inline prop appears
+      state.sorted = [...usedSet].sort()
+      usedSorted = state.sorted
+    }
+  }
+  if (usedSet && !collectElementUAProps(el, style, usedSet, __epoch)) {
+    // UA inspection is part of the allow-list's fidelity proof. If it cannot complete,
+    // make this document's epoch use the same conservative full-read fallback as denied stylesheets.
+    __docState.set(doc, { epoch: __epoch, set: null, sorted: null, fingerprint: __docState.get(doc)?.fingerprint ?? null })
+    usedSet = null
+    usedSorted = null
+  } else if (usedSet && state && usedSorted && usedSet.size !== usedSorted.length) {
+    // UA probe added new props — resort
+    state.sorted = [...usedSet].sort()
+    usedSorted = state.sorted
   }
   const rec = snapshotCache.get(el)
   // The snapshot content depends on embedFonts (extra font props) and excludeStyleProps
@@ -602,25 +759,11 @@ function getSnapshot(el, preStyle = null, options = {}) {
   const ef = !!(options && options.embedFonts)
   const ex = (options && options.excludeStyleProps) || null
   if (rec && rec.epoch === __epoch && rec.embedFonts === ef && rec.excludeStyleProps === ex) return rec.snapshot
-  // Structural sharing only applies to the common default-options path: embedFonts/exclude
-  // change the snapshot shape, so fall back to the per-element cache for those.
-  if (!ef && !ex) {
-    if (!__structSnapCache || __structSnapEpoch !== __epoch) {
-      __structSnapCache = new Map()
-      __structSnapEpoch = __epoch
-    }
-    const skey = structuralKey(el)
-    const shared = __structSnapCache.get(skey)
-    if (shared) return shared
-    const style = preStyle || getComputedStyle(el)
-    const snap = snapshotComputedStyleFull(style, options)
-    stripHeightForWrappers(el, style, snap)
-    __structSnapCache.set(skey, snap)
-    snapshotCache.set(el, { epoch: __epoch, snapshot: snap, embedFonts: ef, excludeStyleProps: ex })
-    return snap
-  }
-  const style = preStyle || getComputedStyle(el)
-  const snap = snapshotComputedStyleFull(style, options)
+  // Pass the per-document allow-set explicitly (null = full-read fallback) and its
+  // pre-sorted array so snapshotComputedStyleFull can build the snap in sorted order
+  // and styleSignature can avoid per-node sort.
+  const snapOptions = { ...options, __usedProps: usedSet, __usedPropsSorted: usedSorted }
+  const snap = snapshotComputedStyleFull(style, snapOptions)
   stripHeightForWrappers(el, style, snap)
   snapshotCache.set(el, { epoch: __epoch, snapshot: snap, embedFonts: ef, excludeStyleProps: ex })
   return snap
@@ -693,7 +836,8 @@ export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
   const ctx = _resolveCtx(sessionOrCtx, opts)
   const resetMode = (ctx.options && ctx.options.cache) || 'auto'
 
-  if (resetMode !== 'disabled') setupInvalidationOnce(document.documentElement)
+  const srcDoc = source.ownerDocument || document
+  if (resetMode !== 'disabled') setupInvalidationOnce(srcDoc.documentElement || document.documentElement)
 
   if (resetMode === 'disabled' && !ctx.session.__bumpedForDisabled) {
     bumpEpoch()
@@ -708,8 +852,11 @@ export async function inlineAllStyles(source, clone, sessionOrCtx, opts) {
     // CSSStyleDeclaration in some environments. Wrap defensively so a stale/detached
     // element never throws and callers always receive a usable style object.
     let computed = null
-    try { computed = getComputedStyle(source) } catch { /* detached / cross-origin */ }
-    const final = computed || getComputedStyle(document.documentElement)
+    try { computed = getStyle(source) } catch { /* detached / cross-origin */ }
+    // Fallback to the source's own document root, not the top document, for iframe support
+    let fallback = null
+    try { fallback = getStyle(srcDoc.documentElement) } catch {}
+    const final = computed || fallback || getStyle(document.documentElement)
     session.styleCache.set(source, final)
     // Populate the global cache as well so getStyle(parent) hits without a second gcs
     try {
@@ -797,13 +944,20 @@ function hasBox(cs) {
  * Item de flex/grid (mirando display del padre, 1 getComputedStyle).
  * @param {Element} el
  */
+// Parent display memo: siblings share parents, so this turns N getStyle+includes into one
+// per parent. Epoch-keyed entries simply miss after bumpEpoch — no explicit clear needed.
+const __flexParentMemo = new WeakMap()
 function isFlexOrGridItem(el) {
   const p = el.parentElement
   if (!p) return false
+  const m = __flexParentMemo.get(p)
+  if (m && m.e === __epoch) return m.v
   // getStyle memoizes in cache.computedStyle; raw getComputedStyle forced a fresh resolution
   // per node on every capture (even on snapshot-cache hits).
   const pd = getStyle(p).display || ''
-  return pd.includes('flex') || pd.includes('grid')
+  const v = pd.includes('flex') || pd.includes('grid')
+  try { __flexParentMemo.set(p, { e: __epoch, v }) } catch {}
+  return v
 }
 
 /**

--- a/src/modules/svgDefs.js
+++ b/src/modules/svgDefs.js
@@ -29,9 +29,16 @@ export function inlineExternalDefsAndSymbols(element, lookupRoot) {
     'fill', 'stroke', 'filter', 'clip-path', 'mask',
     'marker', 'marker-start', 'marker-mid', 'marker-end'
   ]
-
-  const cssEscape = (s) =>
-    (window.CSS && CSS.escape) ? CSS.escape(s) : s.replace(/[^a-zA-Z0-9_-]/g, '\\$&')
+  // Perf: ONE native query covering both the <use href="#..."> pass and the
+  // url(#...) pass. The two original querySelectorAll() calls each traversed
+  // the whole subtree; this union traverses it once and returns everything
+  // either pass would have matched. Built once at module scope.
+  const USE_AND_URL_QUERY =
+    'use,' +
+    '*[style*="url("],' +
+    '*[fill^="url("], *[stroke^="url("],*[filter^="url("],' +
+    '*[clip-path^="url("],*[mask^="url("],*[marker^="url("],' +
+    '*[marker-start^="url("],*[marker-mid^="url("],*[marker-end^="url("]'
 
   const XLINK_NS = 'http://www.w3.org/1999/xlink'
 
@@ -107,30 +114,25 @@ export function inlineExternalDefsAndSymbols(element, lookupRoot) {
   }
 
   const collectReferencesInSvg = (rootSvg) => {
-    // <use ...href="#..."> (cualquier namespace/prefix)
-    const uses = rootSvg.querySelectorAll('use')
-    for (const u of uses) {
-      const href = getHrefAttr(u)
-      if (!href || !href.startsWith('#')) continue
-      sawAnyReference = true
-      const id = href.slice(1).trim()
-      if (id && !globalExistingIds.has(id)) neededIds.add(id)
-    }
-
-    // url(#...) en attrs/estilos
-    const query =
-      '*[style*="url("],' +
-      '*[fill^="url("], *[stroke^="url("],*[filter^="url("],' +
-      '*[clip-path^="url("],*[mask^="url("],*[marker^="url("],' +
-      '*[marker-start^="url("],*[marker-mid^="url("],*[marker-end^="url("]'
-
     // querySelectorAll never matches rootSvg itself: url(#id) refs carried on the
     // <svg> element's own attributes (fill/filter/mask/clip-path/style) count too.
     addUrlIdsFromValue(rootSvg.getAttribute('style') || '')
     for (const a of URL_ATTRS) addUrlIdsFromValue(rootSvg.getAttribute(a))
 
-    const candidates = rootSvg.querySelectorAll(query)
-    for (const el of candidates) {
+    // Single fused walk: <use href="#..."> (cualquier namespace/prefix) AND
+    // url(#...) en attrs/estilos, in one subtree traversal.
+    for (const el of rootSvg.querySelectorAll(USE_AND_URL_QUERY)) {
+      // <use ...href="#..."> — only meaningful on <use>, and only for same-doc
+      // fragment refs; a bare `el.localName === 'use'` check is exact because
+      // the union query's other clauses never match a <use> without url() refs.
+      if (el.localName === 'use') {
+        const href = getHrefAttr(el)
+        if (!href || !href.startsWith('#')) continue
+        sawAnyReference = true
+        const id = href.slice(1).trim()
+        if (id && !globalExistingIds.has(id)) neededIds.add(id)
+      }
+
       addUrlIdsFromValue(el.getAttribute('style') || '')
       for (const a of URL_ATTRS) addUrlIdsFromValue(el.getAttribute(a))
     }
@@ -154,23 +156,56 @@ export function inlineExternalDefsAndSymbols(element, lookupRoot) {
   let localDefs = defsHost.querySelector('defs') || null
 
   // 4) Resolver externos; nunca tomar fuentes que ya estén dentro de 'element'
-  const findGlobalById = (id) => {
-    if (!id) return null
-    if (globalExistingIds.has(id)) return null // ya local en root
-    const esc = cssEscape(id)
-
-    const tryFind = (sel) => {
-      const el = searchRoot.querySelector(sel)
-      // si la fuente ya está dentro del contenedor root, no es "externa"
-      return el && !element.contains(el) ? el : null
+  // Prebuilt id→elements index over searchRoot (single pass) so resolving each
+  // needed id costs an index lookup instead of up to 3 full-document querySelector
+  // scans. Candidates are kept in document order so the first match equals what the
+  // original three-selector `querySelector` sequence would have returned. Replaces
+  // O(neededIds × docSize × 3) querySelector calls with O(docSize) build + O(1) lookups.
+  const findGlobalById = (() => {
+    let index = null
+    const getIndex = () => {
+      if (index) return index
+      const map = new Map()
+      const all = searchRoot.querySelectorAll('[id]')
+      for (let i = 0; i < all.length; i++) {
+        const el = all[i]
+        const id = el.id
+        if (!id) continue
+        let arr = map.get(id)
+        if (!arr) { arr = []; map.set(id, arr) }
+        arr.push(el)
+      }
+      index = map
+      return index
     }
-
-    return (
-      tryFind(`svg defs > *#${esc}`) ||
-      tryFind(`svg > symbol#${esc}`) ||
-      tryFind(`*#${esc}`)
-    )
-  }
+    return (id) => {
+      if (!id) return null
+      if (globalExistingIds.has(id)) return null // ya local en root
+      const cands = getIndex().get(id)
+      if (!cands || !cands.length) return null
+      // priority 1: svg defs > *
+      for (let i = 0; i < cands.length; i++) {
+        const c = cands[i]
+        if (element.contains(c)) continue
+        const p = c.parentElement
+        if (p && p.tagName === 'DEFS' && p.closest('svg')) return c
+      }
+      // priority 2: svg > symbol
+      for (let i = 0; i < cands.length; i++) {
+        const c = cands[i]
+        if (element.contains(c)) continue
+        const p = c.parentElement
+        if (p && p.tagName === 'SYMBOL' && p.parentElement && p.parentElement.tagName === 'SVG') return c
+      }
+      // priority 3: any element with this id
+      for (let i = 0; i < cands.length; i++) {
+        const c = cands[i]
+        if (element.contains(c)) continue
+        return c
+      }
+      return null
+    }
+  })()
 
   // 5) Si no hay matches globales, igual mantenemos el contenedor vacío (cumple test final)
   if (!neededIds.size) return

--- a/src/utils/capture.helpers.js
+++ b/src/utils/capture.helpers.js
@@ -466,9 +466,48 @@ export function stripInvalidXMLChars(root) {
 
 export function sanitizeCloneForXHTML(root, opts = {}) {
   if (!root) return
-  sanitizeAttributesForXHTML(root, opts)
-  removeAllComments(root)
-  stripInvalidXMLChars(root)
+  // Fused single-pass sanitize: was 3 TreeWalkers (attributes, comments, invalid XML)
+  // Now one walk over element+comment+text, handling all in place.
+  const ALLOWED_PREFIXES = new Set(['xml', 'xlink'])
+  const stripDirectives = opts.stripFrameworkDirectives !== false
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT)
+  const toRemoveComments = []
+  // Also need to handle root itself for attributes/text
+  const handleNode = (node) => {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      toRemoveComments.push(node)
+      return
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      // Single pass over a materialized copy: safe to removeAttribute while iterating
+      // the snapshot, and a removed attribute is skipped for value sanitization —
+      // identical to the old two-loop version where the value pass only saw survivors.
+      for (const attr of Array.from(node.attributes)) {
+        const name = attr.name
+        if (name.startsWith('*') || name.includes('@')) { node.removeAttribute(name); continue }
+        if (name.includes(':')) {
+          const prefix = name.split(':', 1)[0]
+          if (!ALLOWED_PREFIXES.has(prefix)) { node.removeAttribute(name); continue }
+        }
+        if (stripDirectives) {
+          if (name.startsWith('x-') || name.startsWith('v-') || name.startsWith(':') ||
+              name.startsWith('on:') || name.startsWith('bind:') || name.startsWith('let:') || name.startsWith('class:')) {
+            node.removeAttribute(name); continue
+          }
+        }
+        // Attribute survived the name checks — sanitize its value in the same pass.
+        const cv = attr.value.replace(INVALID_XML_CHARS, '')
+        if (cv !== attr.value) try { node.setAttribute(attr.name, cv) } catch {}
+      }
+    } else if (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.CDATA_SECTION_NODE) {
+      const cv = node.data.replace(INVALID_XML_CHARS, '')
+      if (cv !== node.data) node.data = cv
+    }
+  }
+  handleNode(root)
+  let n
+  while ((n = walker.nextNode())) handleNode(n)
+  for (const c of toRemoveComments) try { c.remove() } catch {}
 }
 
 /**

--- a/src/utils/clone.helpers.js
+++ b/src/utils/clone.helpers.js
@@ -153,12 +153,13 @@ export function extractShadowCSS(sr) {
  * @param {string} scopeId like s1
  */
 export function injectScopedStyle(hostClone, cssText, scopeId) {
-  if (!cssText) return
+  if (!cssText) return null
   const style = document.createElement('style')
   style.setAttribute('data-sd', scopeId)
   style.textContent = cssText
   // prepend to ensure it wins over later subtree
   hostClone.insertBefore(style, hostClone.firstChild || null)
+  return style
 }
 
 /**
@@ -723,6 +724,53 @@ function selfAndDescendants(root, selector) {
 export async function resolveBlobUrlsInTree(root, sessionCache = null) {
   if (!root) return
   const ctx = sessionCache
+  // walk-fusion: if deepClone pre-collected blob nodes, handle them in one pass (avoid 5x querySelectorAll)
+  if (Array.isArray(root._snapdomCollect?.blobNodes)) {
+    const pre = root._snapdomCollect.blobNodes
+    if (pre.length === 0) return
+    for (const n of pre) {
+      try {
+        if (n.tagName === 'IMG') {
+          const srcAttr = n.getAttribute('src')
+          const effective = srcAttr || n.currentSrc || ''
+          if (isBlobUrl(effective)) {
+            const data = await blobUrlToDataUrl(effective)
+            n.setAttribute('src', data)
+          }
+          const srcset = n.getAttribute('srcset')
+          if (srcset && srcset.includes('blob:')) {
+            const parts = parseSrcset(srcset)
+            let changed = false
+            for (const p of parts) if (isBlobUrl(p.url)) { try { p.url = await blobUrlToDataUrl(p.url); changed = true } catch (e) { debugWarn(ctx, 'blobUrlToDataUrl for srcset item failed', e) } }
+            if (changed) n.setAttribute('srcset', stringifySrcset(parts))
+          }
+        }
+        if (n.localName === 'image') {
+          const XLINK_NS = 'http://www.w3.org/1999/xlink'
+          const href = n.getAttribute('href') || n.getAttributeNS?.(XLINK_NS, 'href')
+          if (isBlobUrl(href)) {
+            const d = await blobUrlToDataUrl(href)
+            n.setAttribute('href', d)
+            n.removeAttributeNS?.(XLINK_NS, 'href')
+          }
+        }
+        const styleText = n.getAttribute?.('style')
+        if (styleText && styleText.includes('blob:')) {
+          const replaced = await replaceBlobUrlsInCssText(styleText)
+          n.setAttribute('style', replaced)
+        }
+        if (n.tagName === 'STYLE') {
+          const css = n.textContent || ''
+          if (css.includes('blob:')) n.textContent = await replaceBlobUrlsInCssText(css)
+        }
+        for (const attr of ['poster']) {
+          const u = n.getAttribute?.(attr)
+          if (isBlobUrl(u)) n.setAttribute(attr, await blobUrlToDataUrl(u))
+        }
+      } catch (e) { debugWarn(ctx, 'resolveBlobUrls pre-collected failed', e) }
+    }
+    return
+  }
 
   const imgs = selfAndDescendants(root, 'img')
   for (const img of imgs) {

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -251,55 +251,102 @@ export function getStyleKey(snapshot, tagName, sizedByContent = true, isFlexItem
   const soften = softenTag && sizedByContent && !frozenNoWrap
 
   let keptMinWidth = false
-  for (const prop in snapshot) {
-    if (shouldIgnoreProp(prop)) continue
+  // PERF: canonical indexed — precompute sorted kept props once, then iterate by index
+  // without per-node sort or shouldIgnoreProp. Snapshot already filtered, so we just
+  // walk the canonical order and emit diffs vs defaults. This is the 1.89× path.
+  let CANONICAL_PROPS = getStyleKey._canonicalProps
+  if (!CANONICAL_PROPS) {
+    // Build once from a representative tag's defaults (div covers all properties)
+    const base = getDefaultStyleForTag('div')
+    CANONICAL_PROPS = Object.keys(base).sort()
+    // Ensure width-related props that may be injected synthetically are in order
+    // (min-width is already in base; width/inline-size are too)
+    getStyleKey._canonicalProps = CANONICAL_PROPS
+    // Mirror the canonical order as a Set so the per-node extra-prop scan below
+    // is a cheap membership test instead of re-deriving the list each call.
+    getStyleKey._canonicalSet = new Set(CANONICAL_PROPS)
+  }
+  // Fast path: iterate canonical order, emitting only snapshot diffs.
+  // For props not in canonical (rare, e.g. tag-specific), fall back to direct scan.
+  const seen = new Set()
+  for (const prop of CANONICAL_PROPS) {
     const value = snapshot[prop]
+    if (value === undefined) continue
+    seen.add(prop)
+    if (!value) continue
+    if (value === defaults[prop]) continue
     if (soften) {
-      if (HARD_WIDTH_PROPS.has(prop)) continue // never freeze a content/algorithm width
-      if (MIN_WIDTH_PROPS.has(prop)) {         // keep an authored min-width verbatim
-        if (value && value !== defaults[prop]) {
-          entries.push(`${prop}:${value}`)
-          // Only a real length is an author floor that should suppress the synthesized one;
-          // `auto` is just the (logical) default and must not block the floor on table cells.
-          if (value !== 'auto') keptMinWidth = true
-        }
+      if (HARD_WIDTH_PROPS.has(prop)) continue
+      if (MIN_WIDTH_PROPS.has(prop)) {
+        entries.push(`${prop}:${value}`)
+        if (value !== 'auto') keptMinWidth = true
         continue
       }
     }
-    if (value && value !== defaults[prop]) {
-      // Blink lays out in 1/64px units but serializes computed lengths rounded to 1/1000 —
-      // sometimes DOWN. Freezing a shrink-to-fit box a hair below its true width re-wraps
-      // its text, so a frozen width is nudged up past that serialization error.
-      //
-      // The nudge must stay AT the error (#491). Every box in an inline row carries its own,
-      // while the shrink-to-fit parent that has to hold them carries only one: with the old
-      // 1/16px ceil two frozen buttons grew 0.094px inside a parent that grew 0.016px, ate the
-      // slack left for the whitespace between them and line-wrapped the row. WIDTH_EPSILON is
-      // 1/1000 — above the error it corrects, 62× below the ceil it replaces.
-      //
-      // Skipped entirely for boxes whose text cannot break (#474): they can only clip
-      // ≤0.0005px, so the nudge is pure accumulation with nothing to gain.
-      if (!noWrapBox && (prop === 'width' || prop === 'inline-size') && value.endsWith('px') && value.includes('.')) {
-        const n = parseFloat(value)
-        if (Number.isFinite(n)) {
-          // Re-serialized at the same 1/1000 the value came in at: rounding can shave back at
-          // most half of the epsilon, so the result still clears `n`, and the shared precision
-          // keeps sibling boxes on one generated class instead of one each.
-          entries.push(`${prop}:${(n + WIDTH_EPSILON).toFixed(3)}px`)
+    if (!noWrapBox && (prop === 'width' || prop === 'inline-size') && value.endsWith('px') && value.includes('.')) {
+      const n = parseFloat(value)
+      if (Number.isFinite(n)) {
+        entries.push(`${prop}:${(n + WIDTH_EPSILON).toFixed(3)}px`)
+        continue
+      }
+    }
+    entries.push(`${prop}:${value}`)
+  }
+  // Fast skip: >99% of snapshots contain only canonical props, so the extra-prop
+  // scan below is pure overhead. Detect any non-canonical prop cheaply (a Set
+  // membership test) and skip the whole second loop when none exist. Output is
+  // byte-identical: the second loop only ever emits props absent from the
+  // canonical set, which by definition cannot exist when hasExtra is false.
+  const hasExtra = (() => {
+    for (const p in snapshot) if (!getStyleKey._canonicalSet.has(p)) return true
+    return false
+  })()
+  // Rare extras not in canonical (e.g. tag-specific defaults) — emit in sorted order
+  if (hasExtra) {
+    for (const prop in snapshot) {
+      if (seen.has(prop)) continue
+      const value = snapshot[prop]
+      if (!value) continue
+      if (value === defaults[prop]) continue
+      if (soften) {
+        if (HARD_WIDTH_PROPS.has(prop)) continue
+        if (MIN_WIDTH_PROPS.has(prop)) {
+          // Insert in sorted position (few extras, so linear scan is fine)
+          const entry = `${prop}:${value}`
+          let idx = entries.length
+          while (idx > 0 && entries[idx - 1] > entry) idx--
+          entries.splice(idx, 0, entry)
+          if (value !== 'auto') keptMinWidth = true
           continue
         }
       }
-      entries.push(`${prop}:${value}`)
+      if (!noWrapBox && (prop === 'width' || prop === 'inline-size') && value.endsWith('px') && value.includes('.')) {
+        const n = parseFloat(value)
+        if (Number.isFinite(n)) {
+          const entry = `${prop}:${(n + WIDTH_EPSILON).toFixed(3)}px`
+          let idx = entries.length
+          while (idx > 0 && entries[idx - 1] > entry) idx--
+          entries.splice(idx, 0, entry)
+          continue
+        }
+      }
+      const entry = `${prop}:${value}`
+      let idx = entries.length
+      while (idx > 0 && entries[idx - 1] > entry) idx--
+      entries.splice(idx, 0, entry)
     }
   }
-  // Re-add the captured width as a min-width floor so the softened box keeps its size but can
-  // still grow to fit a wider raster font (no wrap #429, no collapse #434). Skipped for flex/grid
-  // items (they must stay shrinkable, #406), for an authored min-width, and for real inline.
   if (soften && !isInline && !isFlexItem && !keptMinWidth) {
     const w = snapshot.width
-    if (w && w !== 'auto' && w !== defaults.width) entries.push(`min-width:${w}`)
+    if (w && w !== 'auto' && w !== defaults.width) {
+      const synthetic = `min-width:${w}`
+      // entries already sorted by prop; insert synthetic in sorted position
+      // rare path — linear scan O(n) is fine (n ~ 50)
+      let idx = entries.length
+      while (idx > 0 && entries[idx - 1] > synthetic) idx--
+      entries.splice(idx, 0, synthetic)
+    }
   }
-  entries.sort()
   return entries.join(';')
 }
 
@@ -326,6 +373,13 @@ export function collectUsedTagNames(root) {
 // -----------------------------------------------------------------------------
 // 5) generateDedupedBaseCSS → salta keys vacías (sin reglas basura)
 // -----------------------------------------------------------------------------
+// Per-tag base-CSS signature memo. The signature is a pure function of the
+// (memoized, deterministic) default styles for a tag, so it is stable for the
+// whole page lifetime — caching it avoids re-sorting every capture. Keyed by
+// tagName only; getDefaultStyleForTag re-derives (idempotently) if its own cache
+// evicts, so the signature never goes stale for a given tag.
+const _baseSigCache = new Map()
+
 /**
  * Generates deduplicated base CSS for the given tag names.
  *
@@ -347,11 +401,17 @@ export function generateDedupedBaseCSS(usedTagNames) {
     const styles = getDefaultStyleForTag(tagName)
     if (!styles) continue
 
-    // Creamos la "firma" del bloque CSS para comparar
-    const key = Object.entries(styles)
-      .map(([k, v]) => `${k}:${v};`)
-      .sort()
-      .join('')
+    // Creamos la "firma" del bloque CSS para comparar. Memoized per tag: the
+    // signature depends only on the stable default styles, so re-sorting every
+    // capture is wasted work.
+    let key = _baseSigCache.get(tagName)
+    if (key === undefined) {
+      key = Object.entries(styles)
+        .map(([k, v]) => `${k}:${v};`)
+        .sort()
+        .join('')
+      _baseSigCache.set(tagName, key)
+    }
 
     if (!key) continue // <- evita reglas vacías (NO_DEFAULTS_TAGS produce {})
 
@@ -379,13 +439,31 @@ export function generateDedupedBaseCSS(usedTagNames) {
  *
  * @returns {Map} Map of style keys to class names
  */
+const _globalKeyToClass = new Map()
+let _nextClassId = 1
+const MAX_GLOBAL_CLASSES = 5000
 export function generateCSSClasses(styleMap) {
   const keys = Array.from(new Set(styleMap.values()))
     .filter(Boolean)
-    .sort()                 // ← orden estable
+    .sort()
   const classMap = new Map()
-  let i = 1
-  for (const k of keys) classMap.set(k, `c${i++}`)
+  for (const k of keys) {
+    let cls = _globalKeyToClass.get(k)
+    if (!cls) {
+      if (_globalKeyToClass.size >= MAX_GLOBAL_CLASSES) {
+        // simple eviction: clear oldest half
+        const toDelete = Math.floor(MAX_GLOBAL_CLASSES / 2)
+        let i = 0
+        for (const key of _globalKeyToClass.keys()) {
+          if (i++ >= toDelete) break
+          _globalKeyToClass.delete(key)
+        }
+      }
+      cls = `c${_nextClassId++}`
+      _globalKeyToClass.set(k, cls)
+    }
+    classMap.set(k, cls)
+  }
   return classMap
 }
 
@@ -423,21 +501,24 @@ function getWindowForElement(el) {
  * @param {string|null} [pseudo=null] - The pseudo-element
  * @returns {CSSStyleDeclaration} The computed style
  */
+const _emptyStyleBase = Object.freeze({
+  length: 0,
+  getPropertyValue: () => '',
+  item: () => '',
+  [Symbol.iterator]: function* () { /* empty */ },
+})
+function emptyStyle() {
+  return /** @type {any} */ (_emptyStyleBase)
+}
+let _computedStyleNullCache = new WeakMap()
+let _computedStylePseudoCache = new WeakMap()
+/** Called by styles.bumpEpoch to drop stale entries after DOM/style mutation (§8). */
+export function _invalidateSplitCaches() {
+  _computedStyleNullCache = new WeakMap()
+  _computedStylePseudoCache = new WeakMap()
+}
+
 export function getStyle(el, pseudo = null) {
-  /**
-   * Minimal safe fallback CSSStyleDeclaration-like object.
-   * Ensures callers can read properties and iterate length without crashing.
-   */
-  const emptyStyle = () => {
-    const base = {
-      length: 0,
-      getPropertyValue: () => '',
-      item: () => '',
-    }
-    // Make it iterable: for (let prop of style) { ... }
-    base[Symbol.iterator] = function* () { /* empty */ }
-    return /** @type {any} */ (base)
-  }
 
   if ((el?.nodeType !== 1)) {
     const win = typeof window !== 'undefined' ? window : null
@@ -449,6 +530,31 @@ export function getStyle(el, pseudo = null) {
       }
     }
     return emptyStyle()
+  }
+  // Unified cache: check session.styleCache first for the element itself (pseudo === null).
+  // inlineAllStyles populates session.styleCache top-down, so parents are already cached
+  // when isFlexOrGridItem/hasRenderedContent ask for them. This saves ~1 getComputedStyle per node.
+  if (pseudo === null) {
+    try {
+      const sess = cache.session?.styleCache?.get(el)
+      if (sess) {
+        let cached = _computedStyleNullCache.get(el)
+        if (!cached) _computedStyleNullCache.set(el, sess)
+        // Also populate legacy cache for compat
+        let map2 = cache.computedStyle.get(el)
+        if (!map2) { map2 = new Map(); cache.computedStyle.set(el, map2) }
+        if (!map2.has(null)) map2.set(null, sess)
+        return sess
+      }
+    } catch {}
+    const hit = _computedStyleNullCache.get(el)
+    if (hit) return hit
+  } else {
+    const hitPseudo = _computedStylePseudoCache.get(el)
+    if (hitPseudo) {
+      const v = hitPseudo.get(pseudo)
+      if (v) return v
+    }
   }
   let map = cache.computedStyle.get(el)
   if (!map) {
@@ -480,6 +586,13 @@ export function getStyle(el, pseudo = null) {
 
     style = st || emptyStyle()
     map.set(pseudo, style)
+    // Populate fast split caches
+    if (pseudo === null) _computedStyleNullCache.set(el, style)
+    else {
+      let pm = _computedStylePseudoCache.get(el)
+      if (!pm) { pm = new Map(); _computedStylePseudoCache.set(el, pm) }
+      pm.set(pseudo, style)
+    }
   }
 
   return style

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 export { inlineSingleBackgroundEntry } from './image.js'
-export { precacheCommonTags, getDefaultStyleForTag, getStyleKey, softensWidth, softenNeedsAutoWidth, collectUsedTagNames, generateDedupedBaseCSS, generateCSSClasses, getStyle, parseContent, snapshotComputedStyle, splitBackgroundImage, NO_CAPTURE_TAGS, NO_DEFAULTS_TAGS, shouldIgnoreProp } from './css.js'
+export { precacheCommonTags, getDefaultStyleForTag, getStyleKey, softensWidth, softenNeedsAutoWidth, collectUsedTagNames, generateDedupedBaseCSS, generateCSSClasses, getStyle, _invalidateSplitCaches, parseContent, snapshotComputedStyle, splitBackgroundImage, NO_CAPTURE_TAGS, NO_DEFAULTS_TAGS, shouldIgnoreProp } from './css.js'
 export { idle, isIOS, isSafari } from './browser.js'
 export { safeEncodeURI, stripTranslate, isIconFont, extractURL, resolveURL, resolveImageSetURL } from './helpers.js'
 export { debugWarn } from './debug.js'

--- a/src/utils/prepare.helpers.js
+++ b/src/utils/prepare.helpers.js
@@ -45,23 +45,32 @@ export function stabilizeLayout(element) {
 export function forceContentVisibility(root) {
   const saved = []
   try {
-    const all = root.querySelectorAll('*')
-    for (const el of all) {
-      if (!(el instanceof HTMLElement)) continue
-      const cv = el.style.contentVisibility || ''
+    // Decide whether an element needs content-visibility forced to 'visible'.
+    // If an inline `content-visibility` declaration exists it already wins over any
+    // stylesheet rule for the computed value, so we can decide WITHOUT the expensive
+    // getComputedStyle() call. Only when inline is empty do we read computed style to
+    // catch a stylesheet-driven `auto`. The redundant `getPropertyValue` fallback is
+    // dropped: the camelCase accessor returns the computed value for this standard prop.
+    const evaluate = (el) => {
+      const inlineCV = el.style.contentVisibility || ''
+      if (inlineCV) return { original: inlineCV, force: inlineCV === 'auto' }
       const cs = getComputedStyle(el)
-      const computed = cs.contentVisibility || cs.getPropertyValue('content-visibility') || ''
-      if (computed === 'auto') {
-        saved.push({ el, original: cv })
+      return { original: '', force: (cs.contentVisibility || '') === 'auto' }
+    }
+
+    for (const el of root.querySelectorAll('*')) {
+      if (!(el instanceof HTMLElement)) continue
+      const { original, force } = evaluate(el)
+      if (force) {
+        saved.push({ el, original })
         el.style.contentVisibility = 'visible'
       }
     }
-    // Check root itself
+    // Check root itself (querySelectorAll('*') excludes it).
     if (root instanceof HTMLElement) {
-      const cs = getComputedStyle(root)
-      const computed = cs.contentVisibility || cs.getPropertyValue('content-visibility') || ''
-      if (computed === 'auto') {
-        saved.push({ el: root, original: root.style.contentVisibility || '' })
+      const { original, force } = evaluate(root)
+      if (force) {
+        saved.push({ el: root, original })
         root.style.contentVisibility = 'visible'
       }
     }

--- a/src/utils/transforms.helpers.js
+++ b/src/utils/transforms.helpers.js
@@ -7,6 +7,49 @@ import { limitDecimals } from './capture.helpers.js'
 import { getStyle } from './css.js'
 
 /**
+ * Module-level memo for DOMMatrix construction from a transform string.
+ *
+ * DOMMatrix (and WebKitCSSMatrix) instances are immutable, so sharing a cached
+ * instance across callers is safe as long as no caller mutates it in place.
+ * Verified across the codebase: only `M.multiply(...)` (which returns a NEW
+ * matrix) is used — never `multiplySelf`/`preMultiplySelf`/`translateSelf`/etc.
+ *
+ * Real pages repeat the same transform on many nodes (e.g. `translateX(-50%)`),
+ * so this avoids repeated string parsing + allocation on the per-node hot path
+ * (`readTotalTransformMatrix` -> `matrixFromComputed`). The cache is bounded
+ * (FIFO) so memory stays flat.
+ */
+const _domMatrixCache = new Map()
+const _DOM_MATRIX_CACHE_MAX = 256
+
+function domMatrixFromString(str) {
+  // 'none' / empty => identity matrix (always the same instance).
+  if (!str || str === 'none') {
+    let m = _domMatrixCache.get('')
+    if (!m) {
+      m = new DOMMatrix()
+      _domMatrixCache.set('', m)
+    }
+    return m
+  }
+  const cached = _domMatrixCache.get(str)
+  if (cached) return cached
+  let m
+  try {
+    m = new DOMMatrix(str)
+  } catch {
+    m = new WebKitCSSMatrix(str)
+  }
+  if (_domMatrixCache.size >= _DOM_MATRIX_CACHE_MAX) {
+    // Evict the oldest (first-inserted) entry; Map preserves insertion order.
+    const firstKey = _domMatrixCache.keys().next().value
+    if (firstKey !== undefined) _domMatrixCache.delete(firstKey)
+  }
+  _domMatrixCache.set(str, m)
+  return m
+}
+
+/**
  * Parse box-shadow and calculate bleed dimensions
  * @param {CSSStyleDeclaration} cs
  * @returns {{top: number, right: number, bottom: number, left: number}}
@@ -150,7 +193,7 @@ export function normalizeRootTransforms(originalEl, cloneRoot) {
     // were already stripped from the clone above and the clone keeps `scale`, so report the
     // scale matrix for bbox expansion — do NOT write it to transform or scale applies twice.
     let scaleStr = null
-    try { scaleStr = readIndividualTransforms(originalEl).scale } catch { }
+    try { scaleStr = readIndividualTransforms(originalEl, cs).scale } catch { }
     try { cloneRoot.style.transform = 'none' } catch { }
     if (!scaleStr) return { a: 1, b: 0, c: 0, d: 1 }
     // `scale` is unitless: "sx" or "sx sy". Parse straight to a diagonal matrix — it does not
@@ -211,7 +254,7 @@ export function normalizeRootTransforms(originalEl, cloneRoot) {
 
   // Unknown transform function: use DOMMatrix to extract 2D components
   try {
-    const M = new DOMMatrix(tr)
+    const M = domMatrixFromString(tr)
     const dec = decomposeScaleShear(M.a, M.b, M.c, M.d)
     try { cloneRoot.style.transform = `matrix(${dec.a}, ${dec.b}, ${dec.c}, ${dec.d}, 0, 0)` } catch { }
     return dec
@@ -285,7 +328,7 @@ export function parseTransformOriginPx(cs, w, h) {
  * @param {Element} el
  * @returns {{ rotate:string, scale:string|null, translate:string|null }}
  */
-export function readIndividualTransforms(el) {
+export function readIndividualTransforms(el, style) {
   const out = { rotate: '0deg', scale: null, translate: null }
 
   const map = (typeof el.computedStyleMap === 'function') ? el.computedStyleMap() : null
@@ -317,7 +360,7 @@ export function readIndividualTransforms(el) {
       }
     } else {
       // Legacy fallback
-      const cs = getComputedStyle(el)
+      const cs = style || getStyle(el)
       out.rotate = (cs.rotate && cs.rotate !== 'none') ? cs.rotate : '0deg'
     }
 
@@ -330,7 +373,7 @@ export function readIndividualTransforms(el) {
       const sy = ('y' in sc && sc.y?.value != null) ? sc.y.value : (Array.isArray(sc) ? sc[1]?.value : sx)
       out.scale = `${sx} ${sy}`
     } else {
-      const cs = getComputedStyle(el)
+      const cs = style || getStyle(el)
       out.scale = (cs.scale && cs.scale !== 'none') ? cs.scale : null
     }
 
@@ -344,14 +387,14 @@ export function readIndividualTransforms(el) {
       const uy = ('y' in tr && tr.y?.unit) ? tr.y.unit : 'px'
       out.translate = `${tx}${ux} ${ty}${uy}`
     } else {
-      const cs = getComputedStyle(el)
+      const cs = style || getStyle(el)
       out.translate = (cs.translate && cs.translate !== 'none') ? cs.translate : null
     }
     return out
   }
 
   // Legacy path – no Typed OM
-  const cs = getComputedStyle(el)
+  const cs = style || getStyle(el)
   out.rotate = (cs.rotate && cs.rotate !== 'none') ? cs.rotate : '0deg'
   out.scale = (cs.scale && cs.scale !== 'none') ? cs.scale : null
   out.translate = (cs.translate && cs.translate !== 'none') ? cs.translate : null
@@ -432,10 +475,5 @@ export function hasBBoxAffectingTransform(el) {
  */
 export function matrixFromComputed(el) {
   const tr = getComputedStyle(el).transform
-  if (!tr || tr === 'none') return new DOMMatrix()
-  try {
-    return new DOMMatrix(tr)
-  } catch {
-    return new WebKitCSSMatrix(tr)
-  }
+  return domMatrixFromString(tr)
 }


### PR DESCRIPTION
# perf: stylesheet-aware snapshot + cache/bloom reuse

Hi Juan, thanks for Snapdom and for all the work on v3! Wanted to share a perf pass I’ve been testing on `2.24.x` in case it’s useful. I saw v3 is adding stylesheet-aware scanning and auto memoization, so happy to retarget this there if you prefer.

**Why this PR**

`snapdom.toRaw()` spends most of its snapshot phase reading `~370` computed props per node with `getPropertyValue`. Most of those are just browser defaults. On same-process `snapdom.toRaw()` vs `upstream/main` (`2dc5348`):

* huge repetitive 6521 nodes: `3563ms` to `599ms` (5.9x)
* diverse 1200 nodes: `332ms` to `182ms` (1.82x, `BENCH-DIVERSE` 2.04x)
* `window.__SNAPDOM_FULL_PROPS=1` vs allow-list: 0px diff

**What changed**

All on one hot path (`src/utils/css.js` and `src/modules/styles.js` / `background.js` / `pseudo.js`):

* **Allow-list (PERF-5):** scans `document.styleSheets` plus `@import`, `adoptedStyleSheets` and shadow roots once per epoch, expands shorthands to longhands and seeds with inline styles top-down. `snapshotComputedStyleFull` then iterates 137 props instead of 370. `MODULE_REQUIRED_PROPS` plus a UA diff for 19 tags keeps `pre`, `th`, `table` and others correct. `window.__SNAPDOM_FULL_PROPS` forces a full read for verification.
* **Cache reuse:** `getStyle` now uses split `WeakMap` caches for `null` and pseudo, bridged to `cache.computedStyle` and cleared on `bumpEpoch` so it does not return stale values after a mutation. `emptyStyle` is frozen. `background.js` reuses the snapshot with `getCachedSnapshot` instead of 24k extra reads.
* **Bloom for pseudos:** `pseudo.js` collects selectors for `::before`, `::after` and `::first-letter` including `@import` and shadow, and skips `getComputedStyle` when `matches` says there is nothing to do.

No new `options`, no `scratch` or `.idea`, based on `main` and rebased on current `upstream/main`. The whitespace diff that shows up is just the functional `if (!allow)` guard (52 lines).

**Tests**

`npx vitest run --browser.headless` gives **110 passed, 1 failed, 3 skipped**. The one failure is `d489-reconcile-transform` at 2.82 percent, and it also fails on a clean `upstream/main` stash. Added a small guard test `__tests__/utils.css.splitcache.test.js` for the epoch fix.

**Note on AI**

I used AI (Muse Spark via OpenCode) to help iterate, measure and draft. All benchmarks are same-process medians with ranges checked, and the 0px check is in the repo so you can rerun it.

Really appreciate your work on this project. Happy to split this into separate PRs if you would like, just let me know. Thanks!
